### PR TITLE
fix: Render language picker rows in pushed view

### DIFF
--- a/DictApp/DictApp/Views/SettingsView.swift
+++ b/DictApp/DictApp/Views/SettingsView.swift
@@ -23,30 +23,25 @@ struct SettingsView: View {
 
     private var uiLanguageSection: some View {
         Section("settings.language.section") {
-            Picker(selection: Binding(
-                get: { viewModel.selectedUILanguage },
-                set: { viewModel.updateUILanguage($0) }
-            )) {
-                ForEach(viewModel.availableUILanguages) { language in
-                    HStack {
-                        // `displayKey` resolves to the language name in the
-                        // *current* UI language; `nativeName` stays in the
-                        // language's own script.
-                        Text(LocalizedStringKey(language.displayKey))
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.8)
-                        Spacer()
-                        Text(language.nativeName)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.8)
-                    }
-                    .tag(language)
-                }
+            // `Picker(.navigationLink)` renders empty rows in the pushed list
+            // on iPad iOS 17.5 regardless of whether the row content is a
+            // single Text, an HStack, or a Text-concatenation. Replace the
+            // picker with an explicit `NavigationLink` to a custom selector
+            // view so we control the row rendering directly.
+            NavigationLink {
+                UILanguagePickerView(
+                    languages: viewModel.availableUILanguages,
+                    selection: viewModel.selectedUILanguage,
+                    onSelect: { viewModel.updateUILanguage($0) }
+                )
             } label: {
-                Text("settings.language.picker")
+                LabeledContent {
+                    Text(verbatim: viewModel.selectedUILanguage.nativeName)
+                } label: {
+                    Text("settings.language.picker")
+                }
             }
-            .pickerStyle(.navigationLink)
+            .accessibilityIdentifier("ui_language_link")
         }
     }
 
@@ -146,5 +141,40 @@ struct SettingsView: View {
                 .font(.footnote)
                 .foregroundStyle(.secondary)
         }
+    }
+}
+
+/// Push-style language selector. Replaces the previous
+/// `Picker(.pickerStyle(.navigationLink))` which renders empty rows on
+/// iPad iOS 17.5. A plain `List` of `Button`s gives us full control over
+/// the row layout (localized name + native name + checkmark).
+private struct UILanguagePickerView: View {
+    let languages: [UILanguage]
+    let selection: UILanguage
+    let onSelect: (UILanguage) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        List(languages) { language in
+            Button {
+                onSelect(language)
+                dismiss()
+            } label: {
+                HStack {
+                    Text(LocalizedStringKey(language.displayKey))
+                        .foregroundStyle(.primary)
+                    Spacer()
+                    Text(verbatim: language.nativeName)
+                        .foregroundStyle(.secondary)
+                    if language == selection {
+                        Image(systemName: "checkmark")
+                            .foregroundStyle(.tint)
+                            .padding(.leading, 4)
+                    }
+                }
+            }
+            .accessibilityIdentifier("ui_language_option_\(language.code)")
+        }
+        .navigationTitle("settings.language.picker")
     }
 }


### PR DESCRIPTION
## Summary

Fixes **Issue #32** — Settings → Language opens the pushed picker view with empty rows; only the checkmark indicating the current selection is visible.

## Root cause

`Picker(.pickerStyle(.navigationLink))` does not reliably render row content in the pushed list across iPad iOS 17.5 / iPhone iOS 26.4. Tried variants — `HStack { Text; Spacer; Text }`, single `Text(LocalizedStringKey)`, and a `Text + Text` concatenation — all rendered empty cells with only the selection checkmark visible.

## Fix

- Replace `Picker` with an explicit `NavigationLink` to a new `UILanguagePickerView` struct.
- Destination is a `List` of `Button` rows so we control row layout directly: localized display name (primary), native name (secondary), and a checkmark for the active language.
- Surface the selected language's native name on the collapsed row via `LabeledContent` so Settings shows the current choice at a glance.
- Add an accessibility identifier on the navigation row for UI tests.

## Test plan

- [x] Build passes on iOS Simulator (`xcodebuild build`).
- [x] iPad Pro 13-inch (M4) iOS 17.5: rows now render `Английский English` (en) and `Русский Русский` (ru, with checkmark) when UI is in Russian — verified by hand with the running build.
- [x] Switching language from the picker takes effect immediately (the existing `SettingsViewModel.updateUILanguage` path).
- [x] Same look on iPhone (compact width).

Closes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Redesigned language selection interface in settings with a dedicated view for improved usability
  * Language options now display both localized and native names for clarity
  * Current language selection is now highlighted with a visual indicator
  * Enhanced accessibility features

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyukhin/dict-app/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->