### PR TITLE
feat: Surface real build version with channel suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [Issue #25] Settings → Version now shows the real marketing version from `MARKETING_VERSION` / `CFBundleShortVersionString`, with a `-unreleased` suffix appended on every build that isn't an App-Store-distributed binary (Debug, TestFlight, Ad-Hoc/Enterprise/Developer-export). Channel detection is layered runtime signals (`#if DEBUG`, sandbox receipt path, embedded provisioning profile) so no manual archive-time flag flip is required. A new `AppVersion` value type is the single source of truth for the displayed string, exposing `displayString` for UI and `verboseString` for telemetry consumers.
 - [Issue #19] Comprehensive UI tests for end-to-end user workflows using XCUITest framework with Page Object pattern for maintainability.
 - [Issue #22] Added UI language choice section to Settings tab with English as initial option, preparing for future internationalization.
 - [Issue #15] Added Learning Mode, Reading Mode, and Support stub sections to SettingsView. Support section includes a disabled "Report a Bug" button and a Credits navigation link showing static attribution text.

--- a/DictApp/DictApp.xcodeproj/project.pbxproj
+++ b/DictApp/DictApp.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		A10000000000000000000015 /* DictionaryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000014 /* DictionaryDetailView.swift */; };
 		A10000000000000000000F01 /* test_import_fixture.json in Resources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000F01 /* test_import_fixture.json */; };
 		A10000000000000000000F02 /* test_import_fixture.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000F02 /* test_import_fixture.sqlite */; };
+		D40000000000000000000001 /* AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50000000000000000000001 /* AppVersion.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -96,6 +97,7 @@
 		A20000000000000000000021 /* DictAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DictAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A20000000000000000000F01 /* test_import_fixture.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = test_import_fixture.json; sourceTree = "<group>"; };
 		A20000000000000000000F02 /* test_import_fixture.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = test_import_fixture.sqlite; sourceTree = "<group>"; };
+		D50000000000000000000001 /* AppVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersion.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -159,6 +161,7 @@
 			children = (
 				0748371C2FB75BAA00E3EA41 /* UILanguage.swift */,
 				A20000000000000000000002 /* Models.swift */,
+				D50000000000000000000001 /* AppVersion.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -414,6 +417,7 @@
 				A1000000000000000000000F /* DictionaryEntry+Hashable.swift in Sources */,
 				A10000000000000000000014 /* AboutView.swift in Sources */,
 				A10000000000000000000015 /* DictionaryDetailView.swift in Sources */,
+				D40000000000000000000001 /* AppVersion.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DictApp/DictApp/Models/AppVersion.swift
+++ b/DictApp/DictApp/Models/AppVersion.swift
@@ -1,0 +1,107 @@
+// AppVersion.swift
+// Single source of truth for the running app's version string.
+//
+// Reads `CFBundleShortVersionString` and `CFBundleVersion` from the
+// generated Info.plist (populated at build time from
+// `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` in the Xcode
+// project) and derives a release channel from runtime signals.
+//
+// Pure value type — no UIKit, no SwiftUI, no `@MainActor`. Constant
+// for the lifetime of the process: `AppVersion.current` is computed
+// once and reused.
+
+import Foundation
+
+/// What kind of build is currently running. Detected at runtime so the
+/// developer never has to flip a flag before archiving.
+enum ReleaseChannel {
+    /// `#if DEBUG` is set — Xcode → Run on device/simulator.
+    case debug
+    /// Release config running with a sandbox-receipt — TestFlight
+    /// (or Release-config simulator, rare).
+    case testFlight
+    /// Release config with an embedded provisioning profile — Ad-Hoc,
+    /// Enterprise, or Developer-export distribution.
+    case development
+    /// Release config, no sandbox receipt, no embedded profile —
+    /// genuine App Store-distributed binary.
+    case appStore
+
+    /// Anything except `.appStore` displays with the `-unreleased`
+    /// suffix.
+    var isUnreleased: Bool { self != .appStore }
+}
+
+/// Immutable view of the app's version, build number, and release
+/// channel. Both Settings and `SupportService` read from this single
+/// type so they never disagree on what the running build is.
+struct AppVersion {
+    /// Process-wide singleton. Computed once on first access.
+    static let current = AppVersion()
+
+    /// Marketing version, e.g. `"1.1.0"`. `"unknown"` if the Info.plist
+    /// entry is missing (shouldn't happen with `GENERATE_INFOPLIST_FILE`
+    /// — visible-failure default rather than a fake `"1.0"`).
+    let marketingVersion: String
+
+    /// Build number, e.g. `"2"`. `"0"` if the Info.plist entry is
+    /// missing.
+    let buildNumber: String
+
+    /// The kind of binary this process is — derived from layered
+    /// runtime signals (`#if DEBUG`, receipt path, embedded profile).
+    let channel: ReleaseChannel
+
+    init(bundle: Bundle = .main, channel: ReleaseChannel? = nil) {
+        self.init(
+            infoDictionary: bundle.infoDictionary,
+            channel: channel ?? Self.detectChannel(bundle: bundle)
+        )
+    }
+
+    /// Internal initializer that bypasses `Bundle` entirely. Used by
+    /// unit tests to exercise the missing/malformed-Info.plist paths
+    /// without having to subclass `Bundle` (which iOS caches by path
+    /// and resists overriding).
+    init(infoDictionary: [String: Any]?, channel: ReleaseChannel) {
+        self.marketingVersion = infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        self.buildNumber = infoDictionary?["CFBundleVersion"] as? String ?? "0"
+        self.channel = channel
+    }
+
+    /// What Settings displays: `"1.1.0-unreleased"` for any non-App-Store
+    /// build, `"1.1.0"` for an App Store-distributed binary.
+    var displayString: String {
+        channel.isUnreleased ? "\(marketingVersion)-unreleased" : marketingVersion
+    }
+
+    /// What bug-report telemetry displays. Always includes the build
+    /// number so triage can match a report to a specific archive.
+    /// e.g. `"1.1.0-unreleased (build 2)"`.
+    var verboseString: String {
+        "\(displayString) (build \(buildNumber))"
+    }
+
+    // MARK: - Channel detection
+
+    /// Internal so tests can exercise the resolution rules with a
+    /// controlled `Bundle`. Production callers go through `current`.
+    static func detectChannel(bundle: Bundle = .main) -> ReleaseChannel {
+        #if DEBUG
+        return .debug
+        #else
+        // TestFlight & the Release-config simulator both report
+        // `sandboxReceipt` for the receipt filename. App Store ships
+        // a file literally named `receipt`.
+        if bundle.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt" {
+            return .testFlight
+        }
+        // Ad-Hoc / Enterprise / Developer-export builds carry an
+        // embedded provisioning profile. App Store strips this file.
+        if bundle.url(forResource: "embedded", withExtension: "mobileprovision") != nil {
+            return .development
+        }
+        return .appStore
+        #endif
+    }
+}

--- a/DictApp/DictApp/Models/AppVersion.swift
+++ b/DictApp/DictApp/Models/AppVersion.swift
@@ -52,6 +52,9 @@ struct AppVersion {
     /// runtime signals (`#if DEBUG`, receipt path, embedded profile).
     let channel: ReleaseChannel
 
+    /// Build an `AppVersion` from a `Bundle` (default `.main`). If
+    /// `channel` is `nil`, the channel is detected at runtime from
+    /// receipt and provisioning-profile signals on the same bundle.
     init(bundle: Bundle = .main, channel: ReleaseChannel? = nil) {
         self.init(
             infoDictionary: bundle.infoDictionary,

--- a/DictApp/DictApp/Views/SettingsView.swift
+++ b/DictApp/DictApp/Views/SettingsView.swift
@@ -136,7 +136,8 @@ struct SettingsView: View {
 
     private var versionSection: some View {
         Section {
-            LabeledContent("settings.version", value: "1.0")
+            LabeledContent("settings.version", value: AppVersion.current.displayString)
+                .accessibilityIdentifier("version_value")
             Text("settings.licenseNote")
                 .font(.footnote)
                 .foregroundStyle(.secondary)

--- a/DictApp/DictAppTests/DictAppTests.swift
+++ b/DictApp/DictAppTests/DictAppTests.swift
@@ -698,6 +698,156 @@ final class DictAppTests: XCTestCase {
         return bundle
     }
 
+    // MARK: - Issue #25: Build version information
+    //
+    // `AppVersion` is a pure value type with no UIKit/SwiftUI dependencies,
+    // so we exercise it by injecting a controlled `Bundle` and an explicit
+    // `ReleaseChannel` instead of relying on runtime detection.
+
+    /// `displayString` must drop the `-unreleased` suffix only for the
+    /// `.appStore` channel; every other channel must include it.
+    func testAppVersionDisplayStringSuffixByChannel() throws {
+        let info: [String: Any] = [
+            "CFBundleShortVersionString": "1.1.0",
+            "CFBundleVersion": "2"
+        ]
+
+        // App Store is the *only* channel that hides the suffix.
+        let appStore = AppVersion(infoDictionary: info, channel: .appStore)
+        XCTAssertEqual(appStore.displayString, "1.1.0",
+                       "App Store builds must display the bare marketing version")
+
+        // All other channels must include the suffix — pin every one of
+        // them so a future case added without an `isUnreleased` update is
+        // caught here.
+        let unreleased: [ReleaseChannel] = [.debug, .testFlight, .development]
+        for channel in unreleased {
+            let av = AppVersion(infoDictionary: info, channel: channel)
+            XCTAssertEqual(
+                av.displayString, "1.1.0-unreleased",
+                "Channel \(channel) must display with the '-unreleased' suffix"
+            )
+        }
+    }
+
+    /// `verboseString` must always include the build number in
+    /// parentheses, e.g. `"1.1.0-unreleased (build 2)"`.
+    func testAppVersionVerboseStringIncludesBuild() throws {
+        let info: [String: Any] = [
+            "CFBundleShortVersionString": "1.1.0",
+            "CFBundleVersion": "2"
+        ]
+
+        let unreleased = AppVersion(infoDictionary: info, channel: .debug)
+        XCTAssertEqual(
+            unreleased.verboseString, "1.1.0-unreleased (build 2)",
+            "Non-App-Store verboseString must include the suffix AND the build number"
+        )
+
+        let released = AppVersion(infoDictionary: info, channel: .appStore)
+        XCTAssertEqual(
+            released.verboseString, "1.1.0 (build 2)",
+            "App Store verboseString must drop the suffix but keep the build number"
+        )
+
+        // Multi-digit build — guard against any "single-character only"
+        // formatting bug.
+        let bigBuild: [String: Any] = [
+            "CFBundleShortVersionString": "2.0.0",
+            "CFBundleVersion": "1024"
+        ]
+        XCTAssertEqual(
+            AppVersion(infoDictionary: bigBuild, channel: .appStore).verboseString,
+            "2.0.0 (build 1024)"
+        )
+    }
+
+    /// Missing `CFBundleShortVersionString` and `CFBundleVersion`
+    /// fall back to `"unknown"` and `"0"` respectively rather than
+    /// crashing or returning empty strings.
+    func testAppVersionFallsBackWhenInfoPlistMissing() throws {
+        // Case 1: infoDictionary is nil (no Info.plist at all).
+        let nilVersion = AppVersion(infoDictionary: nil, channel: .appStore)
+        XCTAssertEqual(nilVersion.marketingVersion, "unknown",
+                       "Missing CFBundleShortVersionString must fall back to 'unknown'")
+        XCTAssertEqual(nilVersion.buildNumber, "0",
+                       "Missing CFBundleVersion must fall back to '0'")
+        XCTAssertEqual(nilVersion.displayString, "unknown",
+                       "displayString on appStore channel must still surface the fallback marketing string")
+        XCTAssertEqual(nilVersion.verboseString, "unknown (build 0)",
+                       "verboseString must compose cleanly with the fallback values")
+
+        // Case 2: infoDictionary exists but the keys we care about are absent.
+        let emptyVersion = AppVersion(infoDictionary: [:], channel: .debug)
+        XCTAssertEqual(emptyVersion.marketingVersion, "unknown")
+        XCTAssertEqual(emptyVersion.buildNumber, "0")
+
+        // Case 3: keys exist but the values aren't strings (wrong types in
+        // a malformed plist). The lookup is `info?[...] as? String`, so we
+        // expect the fallback to kick in rather than a runtime crash.
+        let wrongType: [String: Any] = [
+            "CFBundleShortVersionString": 1.0,
+            "CFBundleVersion": 42
+        ]
+        let wrongTypeVersion = AppVersion(infoDictionary: wrongType, channel: .appStore)
+        XCTAssertEqual(wrongTypeVersion.marketingVersion, "unknown",
+                       "Non-string CFBundleShortVersionString must fall back to 'unknown', not crash")
+        XCTAssertEqual(wrongTypeVersion.buildNumber, "0",
+                       "Non-string CFBundleVersion must fall back to '0', not crash")
+    }
+
+    /// `AppVersion.current.marketingVersion` matches the live
+    /// `CFBundleShortVersionString` in `Bundle.main.infoDictionary`,
+    /// guarding against future refactors that drop the lookup.
+    func testAppVersionCurrentMatchesBundle() throws {
+        // The host app bundle holds the real marketing version. The unit
+        // test target is hosted by the app, so resolve robustly.
+        let hostBundle: Bundle = {
+            if let url = Bundle.main.url(forResource: "DictApp", withExtension: "app") {
+                return Bundle(url: url) ?? .main
+            }
+            return .main
+        }()
+
+        let bundleVersion = hostBundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        let bundleBuild = hostBundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+
+        XCTAssertNotNil(bundleVersion,
+                        "Host bundle must expose CFBundleShortVersionString (guarded by GENERATE_INFOPLIST_FILE)")
+        XCTAssertNotNil(bundleBuild,
+                        "Host bundle must expose CFBundleVersion")
+
+        // AppVersion.current reads `Bundle.main`, which for the unit-test
+        // process is the host app (DictApp.app) — the same bundle whose
+        // CFBundleShortVersionString we just read.
+        let current = AppVersion(bundle: hostBundle)
+        XCTAssertEqual(current.marketingVersion, bundleVersion,
+                       "AppVersion.marketingVersion must mirror the bundle's CFBundleShortVersionString")
+        XCTAssertEqual(current.buildNumber, bundleBuild,
+                       "AppVersion.buildNumber must mirror the bundle's CFBundleVersion")
+
+        // The shared `AppVersion.current` instance must agree with a freshly
+        // constructed one against the same bundle — proves the singleton
+        // hasn't been replaced with a stale snapshot.
+        XCTAssertEqual(AppVersion.current.marketingVersion, current.marketingVersion,
+                       "AppVersion.current must equal a fresh AppVersion(bundle:) reading the same plist")
+        XCTAssertEqual(AppVersion.current.buildNumber, current.buildNumber)
+    }
+
+    /// `ReleaseChannel.isUnreleased` is true for every channel except
+    /// `.appStore` — pins the display rule the rest of the system
+    /// depends on.
+    func testReleaseChannelIsUnreleasedRule() throws {
+        XCTAssertTrue(ReleaseChannel.debug.isUnreleased,
+                      "Debug channel must be marked unreleased")
+        XCTAssertTrue(ReleaseChannel.testFlight.isUnreleased,
+                      "TestFlight channel must be marked unreleased")
+        XCTAssertTrue(ReleaseChannel.development.isUnreleased,
+                      "Development/Ad-Hoc/Enterprise channel must be marked unreleased")
+        XCTAssertFalse(ReleaseChannel.appStore.isUnreleased,
+                       "App Store channel is the *only* released channel")
+    }
+
     // MARK: - Performance Tests
 
     /// Measures FTS5 search time on a 100,000-entry database. Target: < 16ms.

--- a/DictApp/DictAppUITests/TestCases/VersionDisplayTests.swift
+++ b/DictApp/DictAppUITests/TestCases/VersionDisplayTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+
+/// UI coverage for Issue #25: the Settings → Version row now reflects
+/// `AppVersion.current.displayString` instead of the hard-coded "1.0".
+/// The accessibility identifier `version_value` on the `LabeledContent`
+/// is the contract these tests pin.
+final class VersionDisplayTests: XCTestCase {
+
+    var app: XCUIApplication!
+    var tabBarPage: TabBarPage!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launch()
+        tabBarPage = TabBarPage(app: app)
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+        tabBarPage = nil
+    }
+
+    /// The version row must exist on Settings, be reachable via its
+    /// accessibility identifier, and display a real version string —
+    /// not the old "1.0" placeholder and not an empty value.
+    ///
+    /// The xcodebuild test target compiles in Debug, so the channel is
+    /// `.debug` → `displayString` must include the `-unreleased` suffix.
+    /// The marketing version itself is environment-dependent (declared
+    /// in MARKETING_VERSION), so we don't pin a specific number — we
+    /// only require that the displayed value contains the value
+    /// `Bundle.main.infoDictionary["CFBundleShortVersionString"]` plus
+    /// the suffix.
+    func testVersionRowDisplaysAppVersion() throws {
+        // 1. Navigate to Settings.
+        tabBarPage.tapSettingsTab()
+        XCTAssertTrue(
+            app.navigationBars["Settings"].waitForExistence(timeout: 10),
+            "Settings screen should appear after tapping the Settings tab"
+        )
+
+        // 2. The version row is in the last section of the Form. Sweep up
+        //    until we find it (Form is a UICollectionView, so cells off-
+        //    screen aren't materialised).
+        let versionRow = app.descendants(matching: .any)[
+            AccessibilityIdentifiers.Settings.versionValue
+        ]
+        var swipes = 0
+        while !versionRow.exists && swipes < 8 {
+            app.swipeUp()
+            swipes += 1
+        }
+        XCTAssertTrue(
+            versionRow.waitForExistence(timeout: 2),
+            "version_value row must be reachable in the Settings form"
+        )
+
+        // 3. Collect the human-readable text for the row. LabeledContent
+        //    exposes its value through one of several XCUI surfaces;
+        //    look at the element's own value/label *and* any descendant
+        //    static texts so we don't depend on iOS version specifics.
+        var visibleStrings: [String] = []
+        if let label = versionRow.label as String?, !label.isEmpty {
+            visibleStrings.append(label)
+        }
+        if let value = versionRow.value as? String, !value.isEmpty {
+            visibleStrings.append(value)
+        }
+        let staticChildren = versionRow.descendants(matching: .staticText)
+        for i in 0..<staticChildren.count {
+            let text = staticChildren.element(boundBy: i).label
+            if !text.isEmpty { visibleStrings.append(text) }
+        }
+        let combined = visibleStrings.joined(separator: " | ")
+
+        // 4. Must NOT be the old hard-coded "1.0" placeholder. We check
+        //    that no visible string is *exactly* "1.0" — substring matches
+        //    against newer versions like "1.0.0" or "1.1.0" don't count.
+        for piece in visibleStrings {
+            XCTAssertNotEqual(
+                piece.trimmingCharacters(in: .whitespaces), "1.0",
+                "Version row still surfaces the old hard-coded '1.0' placeholder; got: \(combined)"
+            )
+        }
+
+        // 5. Debug builds must surface the '-unreleased' suffix. This is
+        //    the visible signal that channel detection is wired up — if
+        //    the suffix were ever silently dropped, this fails loudly.
+        XCTAssertTrue(
+            combined.contains("-unreleased"),
+            "Debug build must display the '-unreleased' suffix; got: \(combined)"
+        )
+
+        // 6. The version string must look like a semantic version
+        //    (digit.digit at minimum). Cheap regex — guards against an
+        //    empty or "unknown" leaking into a properly-configured build.
+        let versionPattern = try NSRegularExpression(pattern: #"\d+\.\d+"#)
+        let range = NSRange(combined.startIndex..., in: combined)
+        XCTAssertGreaterThan(
+            versionPattern.numberOfMatches(in: combined, range: range), 0,
+            "Version row must contain a numeric version (e.g. '1.1.0'); got: \(combined)"
+        )
+
+        // 7. Defensive: the literal fallback string 'unknown' would mean
+        //    Info.plist lost CFBundleShortVersionString during the build.
+        //    Should never happen with GENERATE_INFOPLIST_FILE = YES.
+        XCTAssertFalse(
+            combined.contains("unknown"),
+            "Version row surfaced the fallback 'unknown' — Info.plist is misconfigured: \(combined)"
+        )
+    }
+}

--- a/DictApp/DictAppUITests/TestCases/VersionDisplayTests.swift
+++ b/DictApp/DictAppUITests/TestCases/VersionDisplayTests.swift
@@ -6,9 +6,14 @@ import XCTest
 /// is the contract these tests pin.
 final class VersionDisplayTests: XCTestCase {
 
+    /// Application under test. Recreated for every test method.
     var app: XCUIApplication!
+    /// Page object used to navigate to the Settings tab.
     var tabBarPage: TabBarPage!
 
+    /// Launches the app fresh for each test and wires up the page
+    /// object. Halts the suite on first failure to keep stack traces
+    /// pointing at the real problem.
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
@@ -16,6 +21,7 @@ final class VersionDisplayTests: XCTestCase {
         tabBarPage = TabBarPage(app: app)
     }
 
+    /// Releases per-test state so each method gets a clean slate.
     override func tearDownWithError() throws {
         app = nil
         tabBarPage = nil

--- a/DictApp/DictAppUITests/TestHelpers/AccessibilityIdentifiers.swift
+++ b/DictApp/DictAppUITests/TestHelpers/AccessibilityIdentifiers.swift
@@ -45,6 +45,7 @@ struct AccessibilityIdentifiers {
     // MARK: - Settings View
     struct Settings {
         static let manageDictionariesLink = "manage_dictionaries_link"
+        static let versionValue = "version_value"
         static func dictionaryToggle(source: String) -> String {
             return "dictionary_toggle_\(source)"
         }


### PR DESCRIPTION
## Summary

Implements **Issue #25**. Settings → Version now reads the real `MARKETING_VERSION` from the generated Info.plist and appends `-unreleased` to every non-App-Store build.

## Changes

- **`AppVersion`** (new value type) — single source of truth: `marketingVersion`, `buildNumber`, `channel`, plus `displayString` (Settings) and `verboseString` (telemetry consumers like #8's `SupportService`).
- **Channel detection** is layered runtime signals: `#if DEBUG` → `sandboxReceipt` → `embedded.mobileprovision` → `.appStore`. No archive-time flag flip required.
- **`SettingsView.versionSection`** reads `AppVersion.current.displayString` and tags the row with `version_value` for UI tests.
- **Tests** — 5 unit tests in `DictAppTests` covering display rules, verbose format, missing-Info.plist fallback, and channel rule; 1 UI test (`VersionDisplayTests`) asserts the row is reachable, contains a semver-shaped value, has the `-unreleased` suffix in Debug, and is no longer `"1.0"`.

## Test plan

- [x] Unit + UI tests: 34 passed, 0 failed (iPhone 17 Pro Max, iOS 26.4).
- [x] Build clean on iOS Simulator.

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings now shows the real marketing app version, appending "-unreleased" for non–App Store builds and a plain version for App Store builds; runtime channel detection controls the suffix and displayed strings.
  * Added an accessibility identifier for the version value in Settings.

* **Tests**
  * Added unit and UI tests to validate version formatting, suffix rules, fallback behavior, and that the placeholder "1.0" is not shown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyukhin/dict-app/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->