### PR TITLE
fix: Restore README screenshot links after rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 | Search | Definition | Manage |
 |:---:|:---:|:---:|
-| <img src="Screenshots/screenshot-1-iphone17pm-en.png" width="250"> | <img src="Screenshots/screenshot-2-iphone17pm-en.png" width="250"> | <img src="Screenshots/screenshot-3-iphone17pm-en.png" width="250"> |
+| <img src="Screenshots/screenshot-1-iphone17pm-en.png" width="250" alt="LibreDict search screen on iPhone showing the word lookup field"> | <img src="Screenshots/screenshot-2-iphone17pm-en.png" width="250" alt="LibreDict definition screen showing the entry for a single word"> | <img src="Screenshots/screenshot-3-iphone17pm-en.png" width="250" alt="LibreDict Manage Dictionaries screen listing imported sources"> |
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 | Search | Definition | Manage |
 |:---:|:---:|:---:|
-| <img src="Screenshots/screenshot-1.png" width="250"> | <img src="Screenshots/screenshot-2.png" width="250"> | <img src="Screenshots/screenshot-3.png" width="250"> |
+| <img src="Screenshots/screenshot-1-iphone17pm-en.png" width="250"> | <img src="Screenshots/screenshot-2-iphone17pm-en.png" width="250"> | <img src="Screenshots/screenshot-3-iphone17pm-en.png" width="250"> |
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary

The App Store screenshot refresh (`54d5aab docs: Refresh App Store screenshots for RU launch`, PR #35) renamed the three marketing PNGs to add device-and-locale suffixes:

- `Screenshots/screenshot-1.png` → `screenshot-1-iphone17pm-en.png`
- `Screenshots/screenshot-2.png` → `screenshot-2-iphone17pm-en.png`
- `Screenshots/screenshot-3.png` → `screenshot-3-iphone17pm-en.png`

`README.md`'s Screenshots table still pointed at the old names, so the images render broken on GitHub. Repoint the three links to the new English-locale variants.

## Test plan

- [x] Target files exist on disk under the new paths.
- [ ] Screenshots table renders correctly on the rendered PR diff and on the README once merged.

See also #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README screenshots to reference refreshed device-specific images for clearer, up-to-date visuals.
  * Ensures in-guide images match current UI and device styling so examples and walkthroughs better reflect the app experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyukhin/dict-app/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->