### PR TITLE
feat: Bundle FreeDict English-Spanish dictionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ __pycache__/
 *.pyc
 *.egg-info/
 
+# Build-script download cache (FreeDict TEI tarballs, etc.). Re-fetched
+# from upstream on demand; never committed.
+Scripts/.cache/
+
 # --- IDE / Editor ---
 .idea/
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to **LibreDict** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- [Issue #24] Bundled an English–Spanish dictionary sourced from FreeDict's `eng-spa` TEI/XML release (~64k headwords, GPL-3.0). The conversion lives entirely in `Scripts/build_freedict_eng_spa.py` (TEI parser, POS normalisation, sense aggregation) and the existing `build_seed.py` orchestrator gains a `--skip-spanish` flag and a final FTS rebuild. The app's data layer needs no changes — the new source identifier `freedict-eng-spa` flows through the existing schema, Settings list, and search filter unchanged; the only Swift edits are a one-line badge label in `DictionaryEntry.sourceLabel` and two Credits rows.
+
 ## [1.2.0] - 2026-05-25
 
 ### Added

--- a/DictApp/DictApp/Models/Models.swift
+++ b/DictApp/DictApp/Models/Models.swift
@@ -35,9 +35,12 @@ struct DictionaryEntry: Codable, Identifiable, Equatable, FetchableRecord, Persi
     /// Human-readable source label for display.
     var sourceLabel: String {
         switch source {
-        case "wordnet":     return "WordNet"
-        case "openrussian": return "OpenRussian"
-        default:            return source.capitalized
+        case "wordnet":          return "WordNet"
+        case "openrussian":      return "OpenRussian"
+        // Badge is space-constrained; the full name lives in
+        // `dict_metadata.display_name` (Settings + DictionaryDetailView).
+        case "freedict-eng-spa": return "En–Es"
+        default:                 return source.capitalized
         }
     }
 }

--- a/DictApp/DictApp/Resources/Localizable.xcstrings
+++ b/DictApp/DictApp/Resources/Localizable.xcstrings
@@ -213,6 +213,40 @@
         }
       }
     },
+    "credits.dataSources.freedict" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FreeDict — English–Spanish, GNU GPL"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FreeDict — английский-испанский, GNU GPL"
+          }
+        }
+      }
+    },
+    "credits.dataSources.openrussian" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OpenRussian — Russian-English, CC BY-SA 4.0"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OpenRussian — русско-английский, CC BY-SA 4.0"
+          }
+        }
+      }
+    },
     "credits.dataSources.wordnet" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/DictApp/DictApp/Resources/seed.sqlite
+++ b/DictApp/DictApp/Resources/seed.sqlite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e1a4f46e2e49edacbb52ca575d64335fa7bad7e0004b34111b12745104f630bc
-size 65282048
+oid sha256:07122e64fb08f9135f66de471634539e27a50ff9f6d26d39ee5ea62f9c2d123b
+size 76845056

--- a/DictApp/DictApp/Views/CreditsView.swift
+++ b/DictApp/DictApp/Views/CreditsView.swift
@@ -11,6 +11,8 @@ struct CreditsView: View {
             }
             Section("credits.dataSources.section") {
                 Text("credits.dataSources.wordnet")
+                Text("credits.dataSources.openrussian")
+                Text("credits.dataSources.freedict")
             }
             Section("credits.licenses.section") {
                 Text("credits.licenses.placeholder")

--- a/DictApp/DictAppTests/DictAppTests.swift
+++ b/DictApp/DictAppTests/DictAppTests.swift
@@ -1098,6 +1098,279 @@ final class DictAppTests: XCTestCase {
     }
 
 
+    // MARK: - Issue #24: FreeDict English–Spanish bundle
+    //
+    // The dictionary content itself lives in the bundled `seed.sqlite`,
+    // so coverage spans two surfaces:
+    //   1. Cosmetic Swift (`sourceLabel`, Settings toggle wiring) —
+    //      independent of the seed contents.
+    //   2. Bundled data (metadata row + searchable headwords) — the
+    //      tests query the host bundle's `seed.sqlite` directly via
+    //      GRDB, identical to the pattern in `testBundledSeedIsRealSQLite`.
+    //      If the maintainer hasn't yet regenerated `seed.sqlite` with
+    //      the new source these tests will fail loudly — that's the
+    //      signal that the data step of #24 is incomplete.
+
+    /// The canonical source identifier for the new dictionary. Centralised
+    /// here so a future rename (e.g. moving to ISO-639-3 `eng-spa`
+    /// codepoints) only requires one edit.
+    private static let freeDictEngSpaSource = "freedict-eng-spa"
+
+    /// `DictionaryEntry.sourceLabel` must return the terse "En–Es"
+    /// badge for the new source identifier, not the raw capitalised
+    /// fallback (e.g. "Freedict-Eng-Spa").
+    func testFreeDictSourceLabelIsTerseEnEs() throws {
+        let entry = DictionaryEntry(
+            id: 1,
+            word: "house",
+            definition: "**noun**\n1. casa",
+            phonetic: "haʊs",
+            pos: "noun",
+            source: Self.freeDictEngSpaSource,
+            createdAt: nil
+        )
+        XCTAssertEqual(
+            entry.sourceLabel, "En–Es",
+            "freedict-eng-spa must render as the terse 'En–Es' badge, not the .capitalized fallback"
+        )
+
+        // Negative control: the unknown-source fallback (`.capitalized`)
+        // still produces the wrong-looking 'Freedict-Eng-Spa'. We assert
+        // this here so the test fails if anyone ever removes the switch
+        // case entirely.
+        let fallback = DictionaryEntry(
+            id: nil, word: "x", definition: "", phonetic: "",
+            pos: "", source: Self.freeDictEngSpaSource, createdAt: nil
+        )
+        XCTAssertNotEqual(
+            fallback.sourceLabel, Self.freeDictEngSpaSource.capitalized,
+            "freedict-eng-spa source must short-circuit the .capitalized fallback"
+        )
+
+        // Existing sources must keep their labels (regression guard).
+        let wordnet = DictionaryEntry(
+            id: nil, word: "x", definition: "", phonetic: "",
+            pos: "", source: "wordnet", createdAt: nil
+        )
+        XCTAssertEqual(wordnet.sourceLabel, "WordNet")
+
+        let openRussian = DictionaryEntry(
+            id: nil, word: "x", definition: "", phonetic: "",
+            pos: "", source: "openrussian", createdAt: nil
+        )
+        XCTAssertEqual(openRussian.sourceLabel, "OpenRussian")
+
+        // An entirely unknown source still flows through .capitalized.
+        let unknown = DictionaryEntry(
+            id: nil, word: "x", definition: "", phonetic: "",
+            pos: "", source: "kaikki", createdAt: nil
+        )
+        XCTAssertEqual(unknown.sourceLabel, "Kaikki",
+                       "Unknown sources must fall back to .capitalized")
+    }
+
+    /// The bundled `seed.sqlite` must contain a `dict_metadata` row for
+    /// `freedict-eng-spa` with every contract column populated. We open
+    /// the seed directly (read-only) — the per-test `DatabaseService`
+    /// instance points at a fresh tempDir DB and won't see bundled data.
+    ///
+    /// FAILS LOUDLY if the seed hasn't been regenerated with the new
+    /// source. That's the gate that catches a half-shipped #24.
+    func testFreeDictMetadataRowIsPopulated() throws {
+        let queue = try Self.openBundledSeedReadOnly()
+
+        let row = try queue.read { db -> Row? in
+            try Row.fetchOne(
+                db,
+                sql: """
+                    SELECT source, display_name, version, license, url, description, word_count
+                    FROM dict_metadata
+                    WHERE source = ?
+                    """,
+                arguments: [Self.freeDictEngSpaSource]
+            )
+        }
+
+        let unwrapped = try XCTUnwrap(
+            row,
+            "Bundled seed.sqlite has no dict_metadata row for '\(Self.freeDictEngSpaSource)'. Regenerate via `python Scripts/build_seed.py` before merging Issue #24."
+        )
+
+        let displayName: String = unwrapped["display_name"]
+        let version: String = unwrapped["version"]
+        let license: String = unwrapped["license"]
+        let url: String = unwrapped["url"]
+        let description: String = unwrapped["description"]
+        let wordCount: Int = unwrapped["word_count"]
+
+        XCTAssertFalse(displayName.isEmpty,
+                       "dict_metadata.display_name must be non-empty")
+        XCTAssertFalse(version.isEmpty,
+                       "dict_metadata.version must capture the upstream FreeDict release tag")
+        XCTAssertFalse(url.isEmpty,
+                       "dict_metadata.url must point at FreeDict's project page")
+        XCTAssertTrue(url.contains("freedict"),
+                      "dict_metadata.url should reference 'freedict.org'; got '\(url)'")
+        XCTAssertFalse(description.isEmpty,
+                       "dict_metadata.description must explain the source")
+
+        // GPL text is a hard contract — the bundle ships GPL'd data and
+        // must surface the license text in-app (DictionaryDetailView).
+        XCTAssertFalse(license.isEmpty,
+                       "dict_metadata.license must contain the full GPL text")
+        XCTAssertTrue(license.uppercased().contains("GPL") || license.contains("GNU GENERAL PUBLIC LICENSE"),
+                      "License text must mention GPL — required for GPL compliance; got first 80 chars: \(license.prefix(80))")
+
+        // Success criterion #3 from the design doc: ≥ 50,000 entries.
+        XCTAssertGreaterThanOrEqual(
+            wordCount, 50_000,
+            "FreeDict eng-spa should contribute ≥ 50,000 entries (success criterion #3); got \(wordCount)"
+        )
+    }
+
+    /// At least one *common* English headword from the eng-spa pair must
+    /// be present in the bundled seed under `source = 'freedict-eng-spa'`.
+    /// We try several candidates so the test isn't pinned to a single
+    /// word that could be missing in an upstream release.
+    func testFreeDictHeadwordIsSearchable() throws {
+        let queue = try Self.openBundledSeedReadOnly()
+
+        // Sanity: the source must have a presence in the entries table.
+        let total = try queue.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM entries WHERE source = ?",
+                arguments: [Self.freeDictEngSpaSource]
+            ) ?? 0
+        }
+        XCTAssertGreaterThan(
+            total, 0,
+            "Bundled seed has no entries with source='\(Self.freeDictEngSpaSource)'. Regenerate via `python Scripts/build_seed.py`."
+        )
+
+        // Pick everyday words that every general-purpose English-Spanish
+        // dictionary covers. At least one must hit.
+        let candidates = ["house", "water", "book", "time", "love", "day"]
+        var hits: [String: Int] = [:]
+        try queue.read { db in
+            for word in candidates {
+                let count = try Int.fetchOne(
+                    db,
+                    sql: """
+                        SELECT COUNT(*) FROM entries
+                        WHERE source = ? AND word = ? COLLATE NOCASE
+                        """,
+                    arguments: [Self.freeDictEngSpaSource, word]
+                ) ?? 0
+                hits[word] = count
+            }
+        }
+        let foundWords = hits.filter { $0.value > 0 }.map { $0.key }.sorted()
+        // Halt the test if no candidates hit — continuing would just
+        // emit an index-out-of-range crash on `foundWords[0]`.
+        let probeWord = try XCTUnwrap(
+            foundWords.first,
+            "None of the candidate headwords \(candidates) were found in '\(Self.freeDictEngSpaSource)'. The dictionary is either too small, mis-cased, or mis-tagged. Hits: \(hits)"
+        )
+
+        // Verify the row is fully populated — `definition` non-empty
+        // (sense aggregation worked) and `source` exactly matches (tags
+        // weren't truncated/renamed).
+        let entry = try queue.read { db -> Row? in
+            try Row.fetchOne(
+                db,
+                sql: """
+                    SELECT word, definition, source, pos
+                    FROM entries
+                    WHERE source = ? AND word = ? COLLATE NOCASE
+                    LIMIT 1
+                    """,
+                arguments: [Self.freeDictEngSpaSource, probeWord]
+            )
+        }
+        let unwrapped = try XCTUnwrap(entry,
+                                      "Lookup for '\(probeWord)' in '\(Self.freeDictEngSpaSource)' returned no row")
+        let definition: String = unwrapped["definition"]
+        XCTAssertFalse(definition.isEmpty,
+                       "FreeDict entries must have a non-empty definition; '\(probeWord)' was empty")
+        let actualSource: String = unwrapped["source"]
+        XCTAssertEqual(actualSource, Self.freeDictEngSpaSource,
+                       "Source identifier must match the canonical 'freedict-eng-spa'")
+    }
+
+    /// `SettingsService.isEnabled(source:)` must report the new source as
+    /// enabled on first launch (no UserDefaults entry), persist a toggle
+    /// to off, and persist a toggle back to on — same shape as the
+    /// existing `testSettingsServiceTogglePersists`, scoped to the new id.
+    func testFreeDictSourceTogglePersists() throws {
+        let service = SettingsService.shared
+
+        // Snapshot + restore so we don't bleed state into adjacent tests.
+        let originalEnabled = service.enabledSources
+        addTeardownBlock {
+            service.enabledSources = originalEnabled
+        }
+
+        // First-launch state.
+        service.enabledSources = nil
+        XCTAssertTrue(
+            service.isEnabled(source: Self.freeDictEngSpaSource),
+            "Unknown / first-launch state must treat \(Self.freeDictEngSpaSource) as enabled"
+        )
+
+        let known: Set<String> = ["wordnet", "openrussian", Self.freeDictEngSpaSource]
+
+        // Toggle off.
+        service.setEnabled(false, for: Self.freeDictEngSpaSource, knownSources: known)
+        XCTAssertFalse(
+            service.isEnabled(source: Self.freeDictEngSpaSource),
+            "After setEnabled(false), freedict-eng-spa must report disabled"
+        )
+        // Other sources must remain enabled (the user toggled exactly one).
+        XCTAssertTrue(service.isEnabled(source: "wordnet"),
+                      "Disabling freedict-eng-spa must not affect other sources")
+        XCTAssertTrue(service.isEnabled(source: "openrussian"))
+
+        // Persisted set must contain the other two and exclude ours.
+        let stored = service.enabledSources
+        XCTAssertNotNil(stored, "Persisted enabledSources must exist after any setEnabled call")
+        XCTAssertFalse(stored?.contains(Self.freeDictEngSpaSource) ?? true,
+                       "Persisted set must not contain freedict-eng-spa after toggling it off")
+        XCTAssertTrue(stored?.contains("wordnet") ?? false)
+        XCTAssertTrue(stored?.contains("openrussian") ?? false)
+
+        // Toggle back on.
+        service.setEnabled(true, for: Self.freeDictEngSpaSource, knownSources: known)
+        XCTAssertTrue(
+            service.isEnabled(source: Self.freeDictEngSpaSource),
+            "Re-enabling freedict-eng-spa must be visible immediately"
+        )
+        XCTAssertTrue(service.enabledSources?.contains(Self.freeDictEngSpaSource) ?? false,
+                      "Re-enable must round-trip through UserDefaults")
+    }
+
+    /// Opens the bundled `seed.sqlite` read-only via GRDB so the FreeDict
+    /// tests can probe it without touching the per-test database. Mirrors
+    /// the host-bundle resolution used by `testBundledSeedIsRealSQLite`.
+    private static func openBundledSeedReadOnly() throws -> DatabaseQueue {
+        let hostBundle: Bundle = {
+            if let url = Bundle.main.url(forResource: "DictApp", withExtension: "app") {
+                return Bundle(url: url) ?? .main
+            }
+            return .main
+        }()
+
+        let seedURL = try XCTUnwrap(
+            hostBundle.url(forResource: "seed", withExtension: "sqlite")
+                ?? Bundle.main.url(forResource: "seed", withExtension: "sqlite"),
+            "Bundled seed.sqlite is missing from the app bundle"
+        )
+
+        var config = Configuration()
+        config.readonly = true
+        return try DatabaseQueue(path: seedURL.path, configuration: config)
+    }
+
     // MARK: - Performance Tests
 
     /// Measures FTS5 search time on a 100,000-entry database. Target: < 16ms.

--- a/DictApp/DictAppUITests/PageObjects/SettingsPage.swift
+++ b/DictApp/DictAppUITests/PageObjects/SettingsPage.swift
@@ -4,23 +4,6 @@ class SettingsPage: BasePage {
 
     // MARK: - UI Elements
 
-    /// The Settings form is a SwiftUI `Form`. XCUI exposes it as a
-    /// `collectionView`, `scrollView`, or `table` depending on the OS
-    /// version. We pick the first one that exists; if none do, callers
-    /// fall back to swiping the whole app element.
-    private var form: XCUIElement? {
-        let candidates: [XCUIElement] = [
-            app.collectionViews.firstMatch,
-            app.scrollViews.firstMatch,
-            app.tables.firstMatch
-        ]
-        return candidates.first(where: { $0.exists })
-    }
-
-    private func swipeContainerUp() {
-        if let f = form { f.swipeUp() } else { app.swipeUp() }
-    }
-
     private func toggle(for source: String) -> XCUIElement {
         app.switches[AccessibilityIdentifiers.Settings.dictionaryToggle(source: source)]
     }
@@ -33,12 +16,11 @@ class SettingsPage: BasePage {
     /// Toggle hit-targets in iOS 26 don't toggle on label-area taps), we
     /// retry on the right-edge coordinate where the switch handle lives.
     func tapToggle(source: String) {
-        XCTAssertTrue(
-            waitForToggle(source: source, timeout: TestData.Timeouts.long),
-            "Toggle for '\(source)' should appear in Settings"
-        )
         let sw = toggle(for: source)
-        scrollToElement(sw)
+        XCTAssertTrue(
+            app.scrollToElement(sw),
+            "Toggle for '\(source)' should be reachable in Settings after scrolling"
+        )
         let before = isDictionaryEnabled(source: source)
         sw.tap()
         if !waitForStateChange(source: source, from: before, timeout: 3.0) {
@@ -61,14 +43,20 @@ class SettingsPage: BasePage {
 
     // MARK: - Verification
 
-    /// Waits for the toggle for the given source to appear. Scrolls once if
-    /// the toggle isn't immediately visible (the Dictionaries section may
-    /// be below the fold on smaller screens).
+    /// Waits for the toggle for the given source to appear and become
+    /// hittable. Delegates the scroll search to `XCUIApplication.
+    /// scrollToElement`, which sweeps up then down with a swipe budget
+    /// that handles the SwiftUI Form virtualisation case where the
+    /// Dictionaries section sits below the fold on smaller screens or
+    /// after the section grows (e.g. adding the FreeDict eng-spa row in
+    /// Issue #24 pushed the Russian toggle further down).
+    ///
+    /// The `timeout` parameter is retained for source-compatibility with
+    /// existing callers; the underlying scroll loop is bounded by swipe
+    /// count rather than wall-clock time, and finishes well within the
+    /// previous default budget.
     func waitForToggle(source: String, timeout: TimeInterval = TestData.Timeouts.medium) -> Bool {
-        let sw = toggle(for: source)
-        if sw.waitForExistence(timeout: timeout) { return true }
-        swipeContainerUp()
-        return sw.waitForExistence(timeout: timeout)
+        return app.scrollToElement(toggle(for: source))
     }
 
     /// Returns the SwiftUI Toggle's "on" state, tried via several XCUI
@@ -82,16 +70,6 @@ class SettingsPage: BasePage {
         return nil
     }
 
-    // MARK: - Helpers
-
-    private func scrollToElement(_ element: XCUIElement, maxSwipes: Int = 6) {
-        var swipes = 0
-        while !element.isHittable && swipes < maxSwipes {
-            swipeContainerUp()
-            swipes += 1
-        }
-    }
-
     // MARK: - Manage Dictionaries navigation
 
     private var manageDictionariesLink: XCUIElement {
@@ -103,54 +81,25 @@ class SettingsPage: BasePage {
         return app.descendants(matching: .any)[id]
     }
 
-    /// Waits for the "Manage Dictionaries" navigation row.
+    /// Waits for the "Manage Dictionaries" navigation row to be reachable.
     ///
-    /// The link itself is *unconditionally* rendered inside the
-    /// Dictionaries section in `SettingsView` — it's outside the
-    /// `if dictionaries.isEmpty` branch — so the only failure mode is
-    /// cell-virtualization: SwiftUI's `Form` is backed by a
-    /// `UICollectionView` that only materializes cells in/near the visible
-    /// region. After many launches the simulator's scene-state restoration
-    /// can resume Settings at any scroll offset (often the bottom on warm
-    /// runs), keeping the link off the rendered-cell window. `exists`
-    /// then returns false even though the link is in the SwiftUI view
-    /// hierarchy.
+    /// The link itself is *unconditionally* rendered inside the Dictionaries
+    /// section in `SettingsView` — it's outside the `if dictionaries.isEmpty`
+    /// branch — so the only failure mode is cell-virtualization: SwiftUI's
+    /// `Form` is backed by a `UICollectionView` that only materializes cells
+    /// in/near the visible region.
     ///
-    /// Strategy:
-    ///   1) Wait for *some* sign Settings rendered — the navigation title
-    ///      "Settings". Without this we'd be swiping a tab bar or a wrong
-    ///      form when the tab transition is still in flight.
-    ///   2) Probe for the link. If visible, done.
-    ///   3) Otherwise sweep the form in both directions a few times. We
-    ///      don't know whether scene restoration parked it above or below
-    ///      the fold, so we try down then up.
+    /// Strategy: first wait for the Settings screen itself to mount (so we
+    /// don't swipe on a half-loaded tab transition), then delegate the
+    /// scroll search to the shared `XCUIApplication.scrollToElement` helper.
     func waitForManageDictionariesLink(timeout: TimeInterval = TestData.Timeouts.medium) -> Bool {
-        // 1) Wait for the Settings screen itself to mount — the navigation
-        //    title is the most reliable per-tab indicator and is present
-        //    regardless of `SettingsViewModel.dictionaries` load state.
-        _ = app.navigationBars["Settings"].waitForExistence(timeout: timeout)
-
-        let link = manageDictionariesLink
-        if link.waitForExistence(timeout: 1.0) { return true }
-
-        // 2) Sweep up (reveal content below the fold) — most common case
-        //    on first entry where the form starts at the top.
-        for _ in 0..<6 {
-            swipeContainerUp()
-            if link.waitForExistence(timeout: 0.5) { return true }
-        }
-
-        // 3) Sweep back down — covers the scene-restoration case where the
-        //    form resumed scrolled past the link.
-        for _ in 0..<8 {
-            swipeContainerDown()
-            if link.waitForExistence(timeout: 0.5) { return true }
-        }
-        return false
-    }
-
-    private func swipeContainerDown() {
-        if let f = form { f.swipeDown() } else { app.swipeDown() }
+        // Wait for the Settings screen itself to mount — any navigation
+        // bar is a reliable per-tab indicator and is present regardless
+        // of `SettingsViewModel.dictionaries` load state. Match by
+        // first-existence rather than the localized title "Settings" so
+        // the wait holds under non-English UI languages.
+        _ = app.navigationBars.firstMatch.waitForExistence(timeout: timeout)
+        return app.scrollToElement(manageDictionariesLink)
     }
 
     /// Taps "Manage Dictionaries" and returns the destination page object.
@@ -158,11 +107,9 @@ class SettingsPage: BasePage {
     func tapManageDictionariesLink() -> ManageDictionariesPage {
         XCTAssertTrue(
             waitForManageDictionariesLink(timeout: TestData.Timeouts.long),
-            "Manage Dictionaries link should appear in Settings"
+            "Manage Dictionaries link should be reachable in Settings"
         )
-        let link = manageDictionariesLink
-        scrollToElement(link)
-        link.tap()
+        manageDictionariesLink.tap()
         return ManageDictionariesPage(app: app)
     }
 }

--- a/DictApp/DictAppUITests/TestCases/DictionaryFilterTests.swift
+++ b/DictApp/DictAppUITests/TestCases/DictionaryFilterTests.swift
@@ -25,13 +25,26 @@ final class DictionaryFilterTests: XCTestCase {
     var app: XCUIApplication!
     var tabBarPage: TabBarPage!
 
-    /// The two sources shipped in the seed database.
+    /// The three sources shipped in the seed database.
     private let englishSource = "wordnet"
     private let russianSource = "openrussian"
+    private let englishSpanishSource = "freedict-eng-spa"
 
     /// A search term that exists in OpenRussian and *only* in OpenRussian
     /// (no Cyrillic in WordNet). Disabling OpenRussian must drop it to 0.
     private let russianOnlyTerm = "яблоко"
+
+    /// A Spanish term that exists *only* in FreeDict eng-spa. The `ñ`
+    /// rules out collisions with WordNet's plain-ASCII headwords, and
+    /// the Latin script rules out collisions with OpenRussian's Cyrillic
+    /// content. Verified offline against `seed.sqlite`: 6 matches, all
+    /// `source = 'freedict-eng-spa'`.
+    private let spanishOnlyTerm = "español"
+
+    /// The badge text `DictionaryEntry.sourceLabel` renders for the
+    /// `freedict-eng-spa` source. The dash is U+2013 (en dash), matching
+    /// the literal in `Models.swift`.
+    private let freeDictBadge = "En–Es"
 
     override func setUpWithError() throws {
         continueAfterFailure = false
@@ -120,6 +133,79 @@ final class DictionaryFilterTests: XCTestCase {
         XCTAssertTrue(
             searchPage.waitForNoResults(),
             "With all dictionaries disabled, search must show ContentUnavailableView"
+        )
+    }
+
+    // MARK: - FreeDict eng-spa (Issue #24)
+
+    /// Searching a Spanish-only word ("español", with the unambiguous `ñ`)
+    /// must surface FreeDict eng-spa entries end-to-end:
+    ///   - the results list must be non-empty,
+    ///   - the first row's source badge must read `En–Es`, which is the
+    ///     value `DictionaryEntry.sourceLabel` produces only for the
+    ///     `freedict-eng-spa` source.
+    ///
+    /// Without the badge assertion this test would still pass if some
+    /// other source happened to mention "español" in its definitions; the
+    /// badge proves the contribution comes from the new bundle.
+    func testSearchingSpanishOnlyWordSurfacesFreeDictResults() throws {
+        let searchPage = tabBarPage.tapSearchTab()
+        searchPage.searchFor(spanishOnlyTerm)
+
+        XCTAssertTrue(
+            searchPage.waitForResults(),
+            "Search for '\(spanishOnlyTerm)' must return at least one result from \(englishSpanishSource)"
+        )
+        XCTAssertTrue(
+            searchPage.verifyResultContainsText(freeDictBadge, at: 0),
+            "First result for '\(spanishOnlyTerm)' must carry the '\(freeDictBadge)' source badge, proving the entry came from \(englishSpanishSource)"
+        )
+    }
+
+    /// Disabling `freedict-eng-spa` must eliminate Spanish-only hits, and
+    /// re-enabling must bring them back. Round-trips the toggle so we
+    /// cover both edges of the per-source filter for the new source.
+    ///
+    /// Probing with a term that exists exclusively in `freedict-eng-spa`
+    /// keeps the empty-state assertion meaningful — without an
+    /// exclusivity guarantee, leftover hits from another dictionary's
+    /// loanword entries would mask a regression in the toggle wiring.
+    func testDisablingFreeDictHidesAndRestoresSpanishResults() throws {
+        // 1) Baseline: with all dictionaries enabled, '\(spanishOnlyTerm)'
+        //    returns results.
+        var searchPage = tabBarPage.tapSearchTab()
+        searchPage.searchFor(spanishOnlyTerm)
+        XCTAssertTrue(
+            searchPage.waitForResults(),
+            "Baseline: '\(spanishOnlyTerm)' must return results before toggling"
+        )
+        searchPage.clearOverlaysBeforeTabSwitch()
+
+        // 2) Disable freedict-eng-spa.
+        var settingsPage = tabBarPage.tapSettingsTab()
+        settingsPage.tapToggle(source: englishSpanishSource)
+
+        // 3) The same search now drops to ContentUnavailableView — the
+        //    Spanish-only term has no remaining home in the enabled set.
+        searchPage = tabBarPage.tapSearchTab()
+        searchPage.clearSearch()
+        searchPage.searchFor(spanishOnlyTerm)
+        XCTAssertTrue(
+            searchPage.waitForNoResults(),
+            "After disabling '\(englishSpanishSource)', '\(spanishOnlyTerm)' must show ContentUnavailableView"
+        )
+        searchPage.clearOverlaysBeforeTabSwitch()
+
+        // 4) Re-enable freedict-eng-spa; results must come back.
+        settingsPage = tabBarPage.tapSettingsTab()
+        settingsPage.tapToggle(source: englishSpanishSource)
+
+        searchPage = tabBarPage.tapSearchTab()
+        searchPage.clearSearch()
+        searchPage.searchFor(spanishOnlyTerm)
+        XCTAssertTrue(
+            searchPage.waitForResults(),
+            "After re-enabling '\(englishSpanishSource)', '\(spanishOnlyTerm)' must return results again"
         )
     }
 

--- a/DictApp/DictAppUITests/TestCases/NavigationTests.swift
+++ b/DictApp/DictAppUITests/TestCases/NavigationTests.swift
@@ -52,7 +52,7 @@ final class NavigationTests: XCTestCase {
         // Test navigation to Manage tab
         tabBarPage.tapManageTab()
 
-        XCTAssertTrue(tabBarPage.verifyManageTabSelected(), "Manage tab should be selected")
+        XCTAssertTrue(tabBarPage.verifySettingsTabSelected(), "Settings tab should be selected")
         // Note: Manage tab functionality would need specific verification based on implementation
     }
 
@@ -112,7 +112,7 @@ final class NavigationTests: XCTestCase {
 
         // Move to Manage
         tabBarPage.tapManageTab()
-        XCTAssertTrue(tabBarPage.verifyManageTabSelected(), "Manage tab should be selected")
+        XCTAssertTrue(tabBarPage.verifySettingsTabSelected(), "Settings tab should be selected")
 
         // Return to Search
         let searchPageFinal = tabBarPage.tapSearchTab()

--- a/DictApp/DictAppUITests/TestCases/ReportBugFlowTests.swift
+++ b/DictApp/DictAppUITests/TestCases/ReportBugFlowTests.swift
@@ -43,34 +43,15 @@ final class ReportBugFlowTests: XCTestCase {
 
         // 2. Tap "Report a Bug". Settings is a SwiftUI Form backed by a
         //    UICollectionView with cell virtualisation, and Support is
-        //    below the fold on iPhone — so first wait for the button to
-        //    enter the view hierarchy, then scroll until it is *hittable*
-        //    (existence alone is not enough on cell-virtualised lists),
-        //    and finally assert the post-scroll state before tapping.
+        //    below the fold on iPhone. Delegate the scroll-search to the
+        //    shared `XCUIApplication.scrollToElement` helper — it sweeps
+        //    up then down until the button is `.exists && .isHittable`,
+        //    which is the only state in which a `.tap()` is meaningful.
         let reportBug = app.buttons["report_bug_button"]
-        let form: XCUIElement = {
-            let candidates = [app.collectionViews.firstMatch,
-                              app.scrollViews.firstMatch,
-                              app.tables.firstMatch]
-            return candidates.first(where: { $0.exists }) ?? app
-        }()
-        XCTAssertTrue(reportBug.waitForExistence(timeout: 10),
-                      "Report a Bug button should appear in the Settings hierarchy")
-
-        // Scroll-until-hittable. Bounded so a regression fails the test
-        // rather than spinning forever; the loop check is `isHittable`
-        // (not `exists`) because XCUI considers off-screen cells as
-        // existing but not tappable.
-        var swipes = 0
-        while !reportBug.isHittable && swipes < 8 {
-            form.swipeUp()
-            swipes += 1
-        }
-
+        XCTAssertTrue(app.scrollToElement(reportBug),
+                      "Report a Bug button must be reachable in the Settings form")
         XCTAssertTrue(reportBug.isEnabled,
                       "Report a Bug button should not be disabled (Issue #8)")
-        XCTAssertTrue(reportBug.isHittable,
-                      "Report a Bug button must be hittable after \(swipes) swipe(s); raise the cap if the form grew")
         reportBug.tap()
 
         // 3. The fallback alert appears (no Mail account on simulator).

--- a/DictApp/DictAppUITests/TestCases/SearchFlowTests.swift
+++ b/DictApp/DictAppUITests/TestCases/SearchFlowTests.swift
@@ -86,23 +86,57 @@ final class SearchFlowTests: XCTestCase {
     }
 
     func testSearchToDefinitionNavigation() throws {
-        // Test complete flow from search to definition
+        // End-to-end: search → tap a matching result → definition view loads
+        // with the expected content.
+        //
+        // We don't pin a specific result index. Bundling additional sources
+        // (e.g. the FreeDict eng-spa pair in Issue #24) changes FTS5's BM25
+        // ranking and shuffles the top-N for common headwords, so the old
+        // "result #0 is the WordNet entry" assumption was brittle. Instead,
+        // walk the visible results until one whose definition contains the
+        // expected substring is found, navigating back between attempts.
         let searchTerm = TestData.searchTerms[1] // "test"
+        guard let expectedContent = TestData.expectedResults[searchTerm] else {
+            XCTFail("TestData.expectedResults is missing an entry for '\(searchTerm)'")
+            return
+        }
 
         searchPage.searchFor(searchTerm)
         XCTAssertTrue(searchPage.waitForResults(), "Search results should appear")
 
-        let definitionPage = searchPage.tapSearchResult(at: 0)
+        // Cap the probe so a real regression (the term has no matching
+        // definition at all) fails the test in bounded time. 10 results is
+        // far more than any single source contributes to the top of a query
+        // for a common word — if the expected content isn't in the first 10,
+        // something is genuinely wrong with the seed.
+        let resultCount = searchPage.getResultsCount()
+        XCTAssertGreaterThan(resultCount, 0, "Search for '\(searchTerm)' returned no results")
+        let probeLimit = min(10, resultCount)
 
-        // Verify definition contains expected content
-        XCTAssertTrue(definitionPage.waitForDefinitionToLoad(), "Definition should load")
-
-        if let expectedContent = TestData.expectedResults[searchTerm] {
+        var matchedIndex: Int?
+        for index in 0..<probeLimit {
+            let definitionPage = searchPage.tapSearchResult(at: index)
             XCTAssertTrue(
-                definitionPage.verifyDefinitionContainsText(expectedContent),
-                "Definition should contain expected content"
+                definitionPage.waitForDefinitionToLoad(),
+                "Definition view should load for result #\(index)"
+            )
+            if definitionPage.verifyDefinitionContainsText(expectedContent) {
+                matchedIndex = index
+                break
+            }
+            // Not the match we want — navigate back and try the next one.
+            // The search query stays in the field, so results are intact.
+            definitionPage.navigateBack()
+            XCTAssertTrue(
+                searchPage.waitForResults(),
+                "Results list should re-appear after navigating back from result #\(index)"
             )
         }
+
+        XCTAssertNotNil(
+            matchedIndex,
+            "No result among the first \(probeLimit) for '\(searchTerm)' had a definition containing '\(expectedContent)'"
+        )
     }
 
     func testSearchFieldFunctionality() throws {

--- a/DictApp/DictAppUITests/TestHelpers/UITestHelpers.swift
+++ b/DictApp/DictAppUITests/TestHelpers/UITestHelpers.swift
@@ -56,3 +56,66 @@ extension XCUIElement {
         self.typeText(text)
     }
 }
+
+extension XCUIApplication {
+    /// Returns the scroll container backing the current screen — SwiftUI
+    /// `Form` is a `UICollectionView` on modern iOS, a `UIScrollView` on
+    /// older ones, and `UITableView` on the oldest. Falls back to the app
+    /// element so the caller can always issue a swipe somewhere.
+    fileprivate var scrollContainer: XCUIElement {
+        let candidates: [XCUIElement] = [
+            collectionViews.firstMatch,
+            scrollViews.firstMatch,
+            tables.firstMatch
+        ]
+        return candidates.first(where: { $0.exists }) ?? self
+    }
+
+    /// Scrolls the current scroll container until `element` is both in the
+    /// accessibility hierarchy AND hittable, swiping up first then down.
+    ///
+    /// Why this exists: SwiftUI `Form` virtualises its rows — cells off the
+    /// visible region aren't in the XCUI accessibility tree at all, so
+    /// `waitForExistence` alone fails. Cells just on the edge of the viewport
+    /// register as `.exists` but not `.isHittable`, so a plain existence
+    /// check still leads to a no-op tap. This helper handles both:
+    ///   1. swipes up to expose content below the fold (the common case);
+    ///   2. swipes down as a fallback for the scroll-restoration case where
+    ///      the form resumes scrolled past the target.
+    ///
+    /// Bounded so a regression fails the test rather than spinning forever.
+    ///
+    /// - Parameters:
+    ///   - element: target element. May be a stale or freshly-resolved
+    ///     `XCUIElement`; we re-query `.exists`/`.isHittable` each step.
+    ///   - container: scrollable container to swipe on. Defaults to the
+    ///     first existing collection/scroll/table view; pass an explicit
+    ///     container only when there are multiple on screen.
+    ///   - maxSwipes: per-direction swipe cap. Default 8 each way.
+    /// - Returns: true if `element` ended up hittable; false otherwise.
+    @discardableResult
+    func scrollToElement(
+        _ element: XCUIElement,
+        in container: XCUIElement? = nil,
+        maxSwipes: Int = 8
+    ) -> Bool {
+        if element.exists && element.isHittable { return true }
+
+        let scrollable = container ?? scrollContainer
+
+        // Sweep up first — content typically lives below the initial fold.
+        for _ in 0..<maxSwipes {
+            scrollable.swipeUp()
+            if element.exists && element.isHittable { return true }
+        }
+
+        // Sweep back down — covers the scene-restoration case where the
+        // form resumed scrolled past the target on a warm relaunch.
+        for _ in 0..<maxSwipes {
+            scrollable.swipeDown()
+            if element.exists && element.isHittable { return true }
+        }
+
+        return element.exists && element.isHittable
+    }
+}

--- a/Scripts/build_freedict_eng_spa.py
+++ b/Scripts/build_freedict_eng_spa.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""
+build_freedict_eng_spa.py
+Download the FreeDict English–Spanish (`eng-spa`) TEI/XML release and
+emit `(word, definition, phonetic, pos, source)` tuples that match the
+existing `entries` schema in `seed.sqlite`. Designed to be called from
+`build_seed.py` (orchestrator) but also runnable stand-alone for
+debugging.
+
+Source identifier convention (for multi-language dictionaries):
+    provider-srclang-tgtlang (ISO-639-3 codes)
+e.g. "freedict-eng-spa".
+
+Usage:
+    python Scripts/build_freedict_eng_spa.py            # print summary
+    python Scripts/build_freedict_eng_spa.py --dump 5   # print 5 entries
+
+Requirements:
+    pip install requests defusedxml
+
+Network artifacts (TEI tarballs) are cached under
+`Scripts/.cache/freedict-eng-spa/<version>/` so re-runs are offline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import re
+import sys
+import tarfile
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Public constants — consumed by build_seed.py for dict_metadata.
+# ---------------------------------------------------------------------------
+
+SOURCE = "freedict-eng-spa"
+DISPLAY_NAME = "English – Spanish (FreeDict)"
+URL = "https://freedict.org/freedict-database/eng-spa/"
+
+LICENSE_TEXT = (
+    "GNU General Public License v3.0 (GPL-3.0)\n\n"
+    "Copyright (C) The FreeDict project and contributors.\n\n"
+    "This dictionary is free software: you can redistribute it and/or "
+    "modify it under the terms of the GNU General Public License as "
+    "published by the Free Software Foundation, either version 3 of the "
+    "License, or (at your option) any later version.\n\n"
+    "This dictionary is distributed in the hope that it will be useful, "
+    "but WITHOUT ANY WARRANTY; without even the implied warranty of "
+    "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the "
+    "GNU General Public License for more details.\n\n"
+    "Full license text: https://www.gnu.org/licenses/gpl-3.0.en.html"
+)
+
+DESCRIPTION_TEXT = (
+    "FreeDict is a project that provides free bilingual dictionaries "
+    "in machine-readable form. The English–Spanish (eng-spa) dictionary "
+    "covers approximately 64,000 headwords with translations, parts of "
+    "speech, and pronunciation hints where available.\n\n"
+    "The data is distributed in TEI (Text Encoding Initiative) XML and "
+    "is converted into the app's storage format at build time. The "
+    "underlying entries remain freely redistributable under the GPL."
+)
+
+# ---------------------------------------------------------------------------
+# Network + cache
+# ---------------------------------------------------------------------------
+
+CACHE_ROOT = Path(__file__).parent / ".cache" / "freedict-eng-spa"
+
+# FreeDict hosts dictionaries on their own CDN, one directory per
+# language pair. Each version directory exposes `*.src.tar.xz` (which
+# contains the TEI XML), `*.dictd.tar.xz`, `*.slob`, and `*.stardict.*`.
+FREEDICT_INDEX_URL = "https://download.freedict.org/dictionaries/eng-spa/"
+FREEDICT_VERSION_DIR_RE = re.compile(r'href="([0-9]+\.[0-9.]+)/"')
+FREEDICT_SRC_ASSET = "freedict-eng-spa-{version}.src.tar.xz"
+
+
+def _ensure_requests():
+    """Return the `requests` module, failing fast if it isn't installed.
+
+    Build dependencies are listed in the module docstring; we don't
+    `pip install` at runtime, which would make builds non-deterministic
+    and break in offline/restricted CI."""
+    try:
+        import requests
+    except ImportError as err:
+        raise RuntimeError(
+            "Missing build dependency 'requests'. Install it first: "
+            "pip install requests defusedxml"
+        ) from err
+    return requests
+
+
+def _safe_etree():
+    """Return the defusedxml ElementTree module, failing fast if absent.
+
+    The TEI dump comes from a remote source, so we parse it with
+    defusedxml's hardened `iterparse` to mitigate XML attacks (billion
+    laughs / entity expansion, external entity resolution). Like
+    `_ensure_requests`, this never installs at runtime."""
+    try:
+        import defusedxml.ElementTree as safe_et
+    except ImportError as err:
+        raise RuntimeError(
+            "Missing build dependency 'defusedxml'. Install it first: "
+            "pip install requests defusedxml"
+        ) from err
+    return safe_et
+
+
+def _version_sort_key(v: str) -> tuple:
+    """Sort '2025.11.23' above '0.3.1' above '0.3'. Pure-numeric tuple
+    comparison handles both `0.x` and date-based `YYYY.MM.DD` variants."""
+    parts = []
+    for chunk in v.split("."):
+        try:
+            parts.append(int(chunk))
+        except ValueError:
+            parts.append(-1)
+    return tuple(parts)
+
+
+def _resolve_release(requests_mod) -> tuple[str, str]:
+    """Return (version_tag, download_url) for the newest eng-spa source
+    tarball available on the FreeDict CDN. Falls back to a known-good
+    pinned release if the CDN is unreachable — see `_PINNED_FALLBACK`."""
+    try:
+        resp = requests_mod.get(FREEDICT_INDEX_URL, timeout=30)
+        resp.raise_for_status()
+        versions = FREEDICT_VERSION_DIR_RE.findall(resp.text)
+        if not versions:
+            raise RuntimeError("no version directories found in CDN listing")
+        versions.sort(key=_version_sort_key)
+        latest = versions[-1]
+        url = f"{FREEDICT_INDEX_URL}{latest}/{FREEDICT_SRC_ASSET.format(version=latest)}"
+        return latest, url
+    except Exception as exc:
+        print(f"  WARNING: FreeDict CDN listing failed ({exc}); using pinned fallback.")
+    return _PINNED_FALLBACK
+
+
+# Pinned baseline — updated whenever a known-good release is verified.
+_PINNED_FALLBACK = (
+    "2025.11.23",
+    "https://download.freedict.org/dictionaries/eng-spa/2025.11.23/"
+    "freedict-eng-spa-2025.11.23.src.tar.xz",
+)
+
+
+def _download(requests_mod, url: str, dest: Path) -> None:
+    print(f"  Downloading {url} -> {dest.name}")
+    resp = requests_mod.get(url, stream=True, timeout=120)
+    resp.raise_for_status()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with open(dest, "wb") as out:
+        for chunk in resp.iter_content(chunk_size=64 * 1024):
+            if chunk:
+                out.write(chunk)
+
+
+def _ensure_tarball(version: str, url: str) -> Path:
+    """Return the local path to the cached tarball, downloading if absent."""
+    cache_dir = CACHE_ROOT / version
+    tarball = cache_dir / os.path.basename(url)
+    if tarball.exists() and tarball.stat().st_size > 0:
+        return tarball
+    requests_mod = _ensure_requests()
+    _download(requests_mod, url, tarball)
+    return tarball
+
+
+def _extract_tei(tarball: Path) -> Path:
+    """Extract the .tei file from the tarball and return its path.
+
+    The tarball comes from a remote source, so the member path is
+    validated to stay inside `target_dir` before extraction — a crafted
+    archive with an absolute path or `..` components could otherwise
+    write anywhere on disk (CVE-style tar path traversal)."""
+    with tarfile.open(tarball, "r:*") as tf:
+        tei_members = [m for m in tf.getmembers() if m.name.endswith(".tei")]
+        if not tei_members:
+            raise RuntimeError(f"No .tei file inside {tarball}")
+        member = tei_members[0]
+        target_dir = (tarball.parent / "extracted").resolve()
+        target_dir.mkdir(exist_ok=True)
+
+        dest = (target_dir / member.name).resolve()
+        try:
+            dest.relative_to(target_dir)
+        except ValueError:
+            raise RuntimeError(
+                f"Refusing to extract '{member.name}': resolves outside {target_dir}"
+            )
+
+        # Stream the validated member to the validated destination rather
+        # than letting tarfile choose the path from member.name.
+        extracted = tf.extractfile(member)
+        if extracted is None:
+            raise RuntimeError(f"Member '{member.name}' is not a regular file")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with extracted, open(dest, "wb") as out:
+            out.write(extracted.read())
+        return dest
+
+
+# ---------------------------------------------------------------------------
+# TEI parsing
+# ---------------------------------------------------------------------------
+
+# Default TEI namespace used by FreeDict.
+TEI_NS = "http://www.tei-c.org/ns/1.0"
+NS = {"t": TEI_NS}
+
+
+# Map TEI's abbreviated <pos> values to the long-form labels WordNet uses
+# (so search-result POS lines are consistent across sources).
+POS_NORMALISATION = {
+    "n": "noun",
+    "v": "verb",
+    "vt": "verb",
+    "vi": "verb",
+    "adj": "adjective",
+    "a": "adjective",
+    "adv": "adverb",
+    "r": "adverb",
+    "prep": "preposition",
+    "conj": "conjunction",
+    "pron": "pronoun",
+    "interj": "interjection",
+    "num": "numeral",
+    "art": "article",
+    "phr": "phrase",
+    "pn": "proper noun",
+    "propn": "proper noun",
+    "abbr": "abbreviation",
+}
+
+
+def _normalise_pos(raw: str) -> str:
+    if not raw:
+        return ""
+    key = raw.strip().lower()
+    return POS_NORMALISATION.get(key, key)
+
+
+def _text(elem) -> str:
+    """Concatenated stripped text content of an element, including tails of
+    nested children (e.g. <quote> with embedded markup)."""
+    if elem is None:
+        return ""
+    return "".join(elem.itertext()).strip()
+
+
+def _aggregate_definition(senses_by_pos: dict[str, list[str]]) -> str:
+    """Format senses into the same markdown shape WordNet emits:
+        **noun**
+        1. casa
+        2. hogar (informal)
+    """
+    parts: list[str] = []
+    for pos_label, translations in senses_by_pos.items():
+        if not translations:
+            continue
+        if pos_label:
+            parts.append(f"**{pos_label}**")
+        for i, line in enumerate(translations, 1):
+            parts.append(f"{i}. {line}")
+        parts.append("")
+    return "\n".join(parts).strip()
+
+
+def parse_tei(tei_path: Path) -> list[tuple]:
+    """Stream the TEI file and produce one row per headword.
+
+    Returned tuples are `(word, definition, phonetic, pos, source)` and
+    match the schema of the existing `entries` table.
+    """
+    rows: list[tuple] = []
+    skipped_no_sense = 0
+
+    # iterparse keeps memory bounded — the TEI file can be tens of MB.
+    # defusedxml's iterparse hardens against XML entity-expansion attacks.
+    safe_et = _safe_etree()
+    context = safe_et.iterparse(str(tei_path), events=("end",))
+    for event, elem in context:
+        tag = elem.tag
+        if not tag.endswith("entry"):
+            continue
+
+        orths = elem.findall(".//t:form/t:orth", NS)
+        if not orths:
+            elem.clear()
+            continue
+
+        pos_elem = elem.find(".//t:gramGrp/t:pos", NS)
+        pos_label = _normalise_pos(_text(pos_elem))
+
+        pron_elem = elem.find(".//t:pron", NS)
+        phonetic = _text(pron_elem)
+
+        # Aggregate senses; group by POS so a multi-POS entry renders cleanly.
+        senses_by_pos: dict[str, list[str]] = {pos_label: []}
+        for sense in elem.findall(".//t:sense", NS):
+            translation_chunks: list[str] = []
+            for cit in sense.findall("t:cit", NS):
+                if cit.get("type") != "trans":
+                    continue
+                quote = cit.find("t:quote", NS)
+                qtxt = _text(quote)
+                if qtxt:
+                    translation_chunks.append(qtxt)
+            if not translation_chunks:
+                continue
+            # Append note text in parentheses when present (e.g. "informal").
+            note_elem = sense.find("t:note", NS)
+            note = _text(note_elem)
+            joined = ", ".join(translation_chunks)
+            if note:
+                joined = f"{joined} ({note})"
+            senses_by_pos.setdefault(pos_label, []).append(joined)
+
+        if not senses_by_pos.get(pos_label):
+            skipped_no_sense += 1
+            elem.clear()
+            continue
+
+        definition = _aggregate_definition(senses_by_pos)
+        for orth in orths:
+            word = _text(orth)
+            if not word:
+                continue
+            rows.append((word, definition, phonetic, pos_label, SOURCE))
+
+        elem.clear()
+
+    if skipped_no_sense:
+        print(f"  Skipped {skipped_no_sense} entries with no usable translation.")
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def download_and_parse() -> tuple[list[tuple], str]:
+    """Resolve, fetch, cache, extract, and parse the latest eng-spa TEI.
+
+    Returns:
+        (rows, version) where `rows` is the list of
+        `(word, definition, phonetic, pos, "freedict-eng-spa")` tuples
+        and `version` is the upstream release tag (used by `build_seed`
+        for `dict_metadata.version`).
+    """
+    requests_mod = _ensure_requests()
+    version, url = _resolve_release(requests_mod)
+    tarball = _ensure_tarball(version, url)
+    tei_path = _extract_tei(tarball)
+    rows = parse_tei(tei_path)
+    return rows, version
+
+
+# ---------------------------------------------------------------------------
+# Stand-alone debug runner
+# ---------------------------------------------------------------------------
+
+def _main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dump", type=int, default=0,
+                    help="Print the first N parsed entries and exit.")
+    args = ap.parse_args()
+
+    rows, version = download_and_parse()
+    print(f"\nFreeDict eng-spa {version}: {len(rows):,} entries parsed.")
+    for row in rows[: args.dump]:
+        word, definition, phonetic, pos, source = row
+        print(f"\n--- {word}  [{pos}]  /{phonetic}/ ---")
+        print(definition)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/Scripts/build_seed.py
+++ b/Scripts/build_seed.py
@@ -1,22 +1,31 @@
 #!/usr/bin/env python3
 """
 build_seed.py
-Downloads WordNet (En-En) and OpenRussian (Ru-En) dictionaries, then builds
-a single seed.sqlite with both sources, FTS5 index, and a metadata table.
+Downloads WordNet (En-En), OpenRussian (Ru-En) and FreeDict eng-spa
+(En-Es) dictionaries, then builds a single seed.sqlite containing all
+three sources, an FTS5 index, and a metadata table.
 
 Sources:
-  - WordNet 3.1 via NLTK  (BSD license, Princeton University)
-  - OpenRussian.org        (CC-BY-SA 4.0, community-maintained)
+  - WordNet 3.1 via NLTK   (BSD license, Princeton University)
+  - OpenRussian.org         (CC-BY-SA 4.0, community-maintained)
+  - FreeDict eng-spa        (GPL-3.0, freedict.org — TEI/XML)
+
+Source-identifier convention used by this builder:
+  - single-monolingual / unambiguous → bare provider name
+        e.g. "wordnet", "openrussian".
+  - bilingual / multi-direction → "provider-srclang-tgtlang" with
+    ISO-639-3 codes, e.g. "freedict-eng-spa".
 
 Requirements:
-    pip install nltk requests
+    pip install nltk requests defusedxml
 
 Usage (from project root):
     source .venv/bin/activate
     python Scripts/build_seed.py
     python Scripts/build_seed.py --output DictApp/DictApp/Resources/seed.sqlite
-    python Scripts/build_seed.py --skip-russian   # WordNet only
-    python Scripts/build_seed.py --limit 5000      # subset for testing
+    python Scripts/build_seed.py --skip-russian   # WordNet only (plus eng-spa)
+    python Scripts/build_seed.py --skip-spanish   # skip FreeDict eng-spa
+    python Scripts/build_seed.py --limit 5000     # subset WordNet (testing)
 """
 
 import argparse
@@ -155,7 +164,7 @@ def extract_pos_tags(synsets) -> str:
 
 def insert_wordnet(cur: sqlite3.Cursor, conn: sqlite3.Connection,
                    limit: int | None = None) -> int:
-    print("\n[1/2] WordNet (En-En)")
+    print("\n[1/3] WordNet (En-En)")
     nltk = ensure_nltk()
     from nltk.corpus import wordnet as wn
 
@@ -285,7 +294,7 @@ def parse_openrussian(csv_files: dict[str, str]) -> list[tuple]:
 
 
 def insert_openrussian(cur: sqlite3.Cursor, conn: sqlite3.Connection) -> int:
-    print("\n[2/2] OpenRussian (Ru-En)")
+    print("\n[2/3] OpenRussian (Ru-En)")
     requests_mod = ensure_requests()
 
     try:
@@ -357,6 +366,69 @@ def insert_openrussian(cur: sqlite3.Cursor, conn: sqlite3.Connection) -> int:
 
 
 # ---------------------------------------------------------------------------
+# FreeDict English-Spanish (En-Es)
+# ---------------------------------------------------------------------------
+
+def insert_freedict_eng_spa(cur: sqlite3.Cursor, conn: sqlite3.Connection) -> int:
+    print("\n[3/3] FreeDict (En-Es)")
+    # Imported lazily so a `--skip-spanish` run doesn't need the module
+    # (and so a tools-checkout with an old build_seed.py won't crash on
+    # a missing sibling file).
+    from build_freedict_eng_spa import (
+        download_and_parse,
+        DESCRIPTION_TEXT,
+        DISPLAY_NAME,
+        LICENSE_TEXT,
+        SOURCE,
+        URL as METADATA_URL,
+    )
+
+    # No try/except here: this function only runs when the caller did
+    # NOT pass --skip-spanish, i.e. Spanish was explicitly requested. A
+    # download/parse failure must surface (non-zero exit) instead of
+    # silently shipping a seed without the dictionary the user asked for.
+    # Use --skip-spanish to build without it on purpose.
+    entries, version = download_and_parse()
+
+    print(f"  Parsed {len(entries)} En-Es entries.")
+
+    batch, inserted = [], 0
+    total = len(entries)
+    for i, row in enumerate(entries):
+        batch.append(row)
+        if len(batch) >= 500:
+            cur.executemany(
+                "INSERT OR IGNORE INTO entries(word, definition, phonetic, pos, source) "
+                "VALUES (?, ?, ?, ?, ?)", batch)
+            conn.commit()
+            inserted += len(batch)
+            batch.clear()
+            if total > 0:
+                pct = int((i + 1) / total * 100)
+                print(f"\r  [{pct:3d}%] {inserted} entries...", end="", flush=True)
+    if batch:
+        cur.executemany(
+            "INSERT OR IGNORE INTO entries(word, definition, phonetic, pos, source) "
+            "VALUES (?, ?, ?, ?, ?)", batch)
+        conn.commit()
+        inserted += len(batch)
+
+    count = cur.execute(
+        "SELECT COUNT(*) FROM entries WHERE source=?", (SOURCE,)).fetchone()[0]
+    cur.execute(
+        "INSERT OR REPLACE INTO dict_metadata(source, display_name, version, license, url, word_count, built_at, description) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (SOURCE, DISPLAY_NAME, version,
+         LICENSE_TEXT,
+         METADATA_URL,
+         count, datetime.now(tz=None).isoformat(),
+         DESCRIPTION_TEXT))
+    conn.commit()
+    print(f"\n  FreeDict: {count} entries")
+    return count
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -368,12 +440,18 @@ def main():
     parser.add_argument("--limit", "-l", type=int, default=None,
                         help="Limit WordNet to first N lemmas (for testing).")
     parser.add_argument("--skip-russian", action="store_true",
-                        help="Only build the WordNet dictionary.")
+                        help="Skip the OpenRussian dictionary.")
+    parser.add_argument("--skip-spanish", action="store_true",
+                        help="Skip the FreeDict English-Spanish dictionary.")
     args = parser.parse_args()
 
     os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
     if os.path.exists(args.output):
         os.remove(args.output)
+
+    # Allow `build_freedict_eng_spa` to be imported when this script is
+    # run from any working directory.
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
     conn = sqlite3.connect(args.output)
     cur = conn.cursor()
@@ -383,6 +461,16 @@ def main():
     ru_count = 0
     if not args.skip_russian:
         ru_count = insert_openrussian(cur, conn)
+    es_count = 0
+    if not args.skip_spanish:
+        es_count = insert_freedict_eng_spa(cur, conn)
+
+    # Rebuild FTS index in bulk. Per-row triggers already kept it in sync
+    # during the inserts, but a final rebuild produces a smaller,
+    # read-optimised index for the shipped seed.
+    print("\nRebuilding FTS index...")
+    cur.execute("INSERT INTO entries_fts(entries_fts) VALUES('rebuild')")
+    conn.commit()
 
     total = cur.execute("SELECT COUNT(*) FROM entries").fetchone()[0]
     size_mb = os.path.getsize(args.output) / (1024 * 1024)
@@ -394,6 +482,7 @@ def main():
     print(f"  Size     : {size_mb:.1f} MB")
     print(f"  WordNet  : {wn_count:,} entries")
     print(f"  OpenRus  : {ru_count:,} entries")
+    print(f"  FreeDict : {es_count:,} entries")
     print(f"  Total    : {total:,} entries")
     print(f"{'='*50}")
 


### PR DESCRIPTION
## Summary

Bundle FreeDict's `eng-spa` TEI/XML dictionary (~59k entries, GPL-3.0)
so the app ships with English ↔ Spanish coverage alongside WordNet and
OpenRussian. `seed.sqlite` ends at 73.3 MB / 251,899 entries.

## Changes

- New `Scripts/build_freedict_eng_spa.py` — CDN download, cache, TEI
  iterparse, POS normalisation, sense aggregation.
- `Scripts/build_seed.py` — third inserter, `--skip-spanish` flag,
  final FTS rebuild.
- `DictionaryEntry.sourceLabel` — one new "En–Es" badge case; the
  rest of the data layer was already source-agnostic.
- `CreditsView` — FreeDict + the previously-missing OpenRussian rows.

## Tests

Two new UI tests in `DictionaryFilterTests` probe with `"español"`
(the ñ rules out WordNet's ASCII headwords; Latin script rules out
OpenRussian's Cyrillic — any hit must come from the new source):

- `testSearchingSpanishOnlyWordSurfacesFreeDictResults` — asserts the
  "En–Es" source badge on the first result.
- `testDisablingFreeDictHidesAndRestoresSpanishResults` — round-trips
  the Settings toggle.

Plus a stability pass on the existing UI suite: bundling ~59k more
entries shifted BM25 ranking and grew Settings → Dictionaries past
the hand-rolled scroll budgets, producing 9 unrelated-looking
failures. Fixed with a bounded result-probe in
`testSearchToDefinitionNavigation` and a shared
`XCUIApplication.scrollToElement` helper that collapses four bespoke
scroll loops. Also points two stale `NavigationTests` call sites at
the renamed `verifySettingsTabSelected()` helper, silencing the
warnings left over from the earlier Manage-tab rename.

Closes #24


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundled FreeDict English–Spanish dictionary (~64k headwords); Spanish-only queries now surface results and a compact "En–Es" source badge appears with a Settings toggle.

* **Documentation**
  * Credits updated to acknowledge FreeDict (GPL‑3.0) and OpenRussian (CC BY‑SA 4.0).

* **Tests**
  * New unit and UI tests for FreeDict content, toggling, search behavior, and more robust UI scrolling helpers.

* **Chores**
  * Added gitignore rules to exclude build-script cache files; bundled seed database pointer updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyukhin/dict-app/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->