### PR TITLE
feat: Bundle Spanish-English dictionary (Spanish WordNet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [Issue #42] Bundled a Spanish–English dictionary built from Spanish WordNet (MCR data via NLTK's Open Multilingual WordNet). The synset mapping the issue called for happens at build time in `Scripts/build_spanish_wordnet.py`: Spanish lemmas and their English glosses/synonyms are read from a single WordNet 3.0 instance, so synset IDs align by construction with no LKB parser and no cross-version risk. `build_seed.py` gains an `insert_spanish_wordnet()` step and a `--skip-spanish-wordnet` flag; the app picks up the new `wordnet-spa-eng` source with only a badge label and a Credits row. Also corrects the English `wordnet` metadata version from `3.1` to the actual `3.0`.
 - [Issue #24] Bundled an English–Spanish dictionary sourced from FreeDict's `eng-spa` TEI/XML release (~64k headwords, GPL-3.0). The conversion lives entirely in `Scripts/build_freedict_eng_spa.py` (TEI parser, POS normalisation, sense aggregation) and the existing `build_seed.py` orchestrator gains a `--skip-spanish` flag and a final FTS rebuild. The app's data layer needs no changes — the new source identifier `freedict-eng-spa` flows through the existing schema, Settings list, and search filter unchanged; the only Swift edits are a one-line badge label in `DictionaryEntry.sourceLabel` and two Credits rows.
 
 ## [1.2.0] - 2026-05-25

--- a/DictApp/DictApp/Models/Models.swift
+++ b/DictApp/DictApp/Models/Models.swift
@@ -40,6 +40,7 @@ struct DictionaryEntry: Codable, Identifiable, Equatable, FetchableRecord, Persi
         // Badge is space-constrained; the full name lives in
         // `dict_metadata.display_name` (Settings + DictionaryDetailView).
         case "freedict-eng-spa": return "En–Es"
+        case "wordnet-spa-eng":  return "Es–En"
         default:                 return source.capitalized
         }
     }

--- a/DictApp/DictApp/Resources/Localizable.xcstrings
+++ b/DictApp/DictApp/Resources/Localizable.xcstrings
@@ -230,6 +230,23 @@
         }
       }
     },
+    "credits.dataSources.spanishWordnet" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spanish WordNet (MCR / OMW) — Spanish-English, CC BY 3.0"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spanish WordNet (MCR / OMW) — испанско-английский, CC BY 3.0"
+          }
+        }
+      }
+    },
     "credits.dataSources.openrussian" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/DictApp/DictApp/Resources/seed.sqlite
+++ b/DictApp/DictApp/Resources/seed.sqlite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:07122e64fb08f9135f66de471634539e27a50ff9f6d26d39ee5ea62f9c2d123b
-size 76845056
+oid sha256:f6da057fdacd7a5c6b222a83d015cd2c304022dd1f2f2bb5ecd13fa00da5392a
+size 91389952

--- a/DictApp/DictApp/Views/CreditsView.swift
+++ b/DictApp/DictApp/Views/CreditsView.swift
@@ -13,6 +13,7 @@ struct CreditsView: View {
                 Text("credits.dataSources.wordnet")
                 Text("credits.dataSources.openrussian")
                 Text("credits.dataSources.freedict")
+                Text("credits.dataSources.spanishWordnet")
             }
             Section("credits.licenses.section") {
                 Text("credits.licenses.placeholder")

--- a/DictApp/DictAppTests/DictAppTests.swift
+++ b/DictApp/DictAppTests/DictAppTests.swift
@@ -1371,6 +1371,248 @@ final class DictAppTests: XCTestCase {
         return try DatabaseQueue(path: seedURL.path, configuration: config)
     }
 
+    // MARK: - Issue #42: Spanish WordNet (Spanish–English) bundle
+    //
+    // Content lives in the bundled `seed.sqlite` under source
+    // `wordnet-spa-eng`, so coverage mirrors the #24 FreeDict tests:
+    //   1. Cosmetic Swift (sourceLabel, Settings toggle) — independent of
+    //      the seed contents.
+    //   2. Bundled data (metadata row + searchable headwords) — queried
+    //      directly via `openBundledSeedReadOnly()`. These fail loudly if
+    //      the maintainer hasn't regenerated `seed.sqlite` with the new
+    //      source, which is the signal that the data step of #42 is
+    //      incomplete.
+
+    /// Canonical source identifier for Spanish WordNet (spa→eng). Follows
+    /// the #24 `provider-srclang-tgtlang` convention. Centralised so a
+    /// future rename is a one-line edit.
+    private static let spanishWordNetSource = "wordnet-spa-eng"
+
+    /// `DictionaryEntry.sourceLabel` must return the terse "Es–En" badge
+    /// for the Spanish WordNet source identifier, not the raw
+    /// capitalised fallback.
+    func testSpanishWordNetSourceLabelIsTerseEsEn() throws {
+        let entry = DictionaryEntry(
+            id: 1, word: "casa",
+            definition: "**noun**\n1. house, home — a dwelling…",
+            phonetic: "", pos: "noun",
+            source: Self.spanishWordNetSource, createdAt: nil
+        )
+        XCTAssertEqual(
+            entry.sourceLabel, "Es–En",
+            "wordnet-spa-eng must render as the terse 'Es–En' badge, not the .capitalized fallback"
+        )
+
+        // The .capitalized fallback would produce 'Wordnet-Spa-Eng'. The
+        // switch case must short-circuit it.
+        XCTAssertNotEqual(
+            entry.sourceLabel, Self.spanishWordNetSource.capitalized,
+            "wordnet-spa-eng source must short-circuit the .capitalized fallback"
+        )
+
+        // Regression guards: existing sources keep their labels, and the
+        // sibling bilingual source from #24 is not confused with this one.
+        XCTAssertEqual(
+            DictionaryEntry(id: nil, word: "x", definition: "", phonetic: "",
+                            pos: "", source: "wordnet", createdAt: nil).sourceLabel,
+            "WordNet",
+            "Plain 'wordnet' must stay 'WordNet', not collide with the spa-eng label"
+        )
+        XCTAssertEqual(
+            DictionaryEntry(id: nil, word: "x", definition: "", phonetic: "",
+                            pos: "", source: "freedict-eng-spa", createdAt: nil).sourceLabel,
+            "En–Es",
+            "The #24 eng-spa source must keep its 'En–Es' badge (opposite direction)"
+        )
+    }
+
+    /// The bundled DB must carry a `dict_metadata` row for
+    /// `wordnet-spa-eng` with non-empty license, display_name, version
+    /// (accurately naming the WordNet/OMW version), url, and description.
+    ///
+    /// FAILS LOUDLY if the seed hasn't been regenerated with the new
+    /// source — the gate that catches a half-shipped #42.
+    func testSpanishWordNetMetadataRowIsPopulated() throws {
+        let queue = try Self.openBundledSeedReadOnly()
+
+        let row = try queue.read { db -> Row? in
+            try Row.fetchOne(
+                db,
+                sql: """
+                    SELECT source, display_name, version, license, url, description, word_count
+                    FROM dict_metadata
+                    WHERE source = ?
+                    """,
+                arguments: [Self.spanishWordNetSource]
+            )
+        }
+
+        let unwrapped = try XCTUnwrap(
+            row,
+            "Bundled seed.sqlite has no dict_metadata row for '\(Self.spanishWordNetSource)'. Regenerate via `python Scripts/build_seed.py` before merging Issue #42."
+        )
+
+        let displayName: String = unwrapped["display_name"]
+        let version: String = unwrapped["version"]
+        let license: String = unwrapped["license"]
+        let url: String = unwrapped["url"]
+        let description: String = unwrapped["description"]
+        let wordCount: Int = unwrapped["word_count"]
+
+        XCTAssertFalse(displayName.isEmpty,
+                       "dict_metadata.display_name must be non-empty")
+        XCTAssertFalse(url.isEmpty,
+                       "dict_metadata.url must point at the MCR / OMW project page")
+        XCTAssertFalse(description.isEmpty,
+                       "dict_metadata.description must explain the source")
+
+        // The design doc's central correctness point: the version must
+        // *accurately* name the WordNet/OMW version used (the English
+        // wordnet row's "3.1" is a known mislabel). Require a version-like
+        // token so a blank or stub value fails.
+        XCTAssertFalse(version.isEmpty,
+                       "dict_metadata.version must state the WordNet/OMW version used")
+        XCTAssertTrue(
+            version.range(of: #"\d"#, options: .regularExpression) != nil,
+            "dict_metadata.version should contain a version number (e.g. 'OMW 1.4 / WordNet 3.0'); got '\(version)'"
+        )
+
+        // License text is a hard contract — the bundle ships licensed data
+        // and surfaces the text in DictionaryDetailView. Guard against an
+        // empty or stub value.
+        XCTAssertGreaterThan(
+            license.count, 50,
+            "dict_metadata.license must contain real license text, not a stub; got \(license.count) chars"
+        )
+
+        // Success criterion #1 from the design doc: ≥ 30,000 entries.
+        XCTAssertGreaterThanOrEqual(
+            wordCount, 30_000,
+            "Spanish WordNet should contribute ≥ 30,000 entries (design doc success criterion); got \(wordCount)"
+        )
+    }
+
+    /// A common Spanish headword must be present under `wordnet-spa-eng`,
+    /// and its definition must lead with the correct English translation —
+    /// which also verifies the synset mapping resolved Spanish→English to
+    /// the *right* synset (the design doc's "Critical Risk").
+    func testSpanishWordNetHeadwordIsSearchable() throws {
+        let queue = try Self.openBundledSeedReadOnly()
+
+        // Sanity: the source must have a presence in the entries table.
+        let total = try queue.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM entries WHERE source = ?",
+                arguments: [Self.spanishWordNetSource]
+            ) ?? 0
+        }
+        XCTAssertGreaterThan(
+            total, 0,
+            "Bundled seed has no entries with source='\(Self.spanishWordNetSource)'. Regenerate via `python Scripts/build_seed.py`."
+        )
+
+        // Spanish headword → an English translation lemma that the correct
+        // synset must contain. These are the sampled mappings the design
+        // doc calls out (casa→house, perro→dog, agua→water). Probing
+        // several guards against any single lemma being absent upstream.
+        let expectedTranslations: [String: String] = [
+            "casa": "house",
+            "perro": "dog",
+            "agua": "water",
+            "libro": "book",
+            "gato": "cat"
+        ]
+
+        var probed: [String: String] = [:]   // spanish -> its definition (when found)
+        try queue.read { db in
+            for spanish in expectedTranslations.keys {
+                if let def = try String.fetchOne(
+                    db,
+                    sql: """
+                        SELECT definition FROM entries
+                        WHERE source = ? AND word = ?
+                        LIMIT 1
+                        """,
+                    arguments: [Self.spanishWordNetSource, spanish]
+                ) {
+                    probed[spanish] = def
+                }
+            }
+        }
+
+        // Require at least one candidate present (guards against an empty
+        // or missing source), then validate the synset alignment for
+        // *every* probed hit — not just the first — so a single wrong
+        // mapping can't slip through behind a correct one.
+        XCTAssertFalse(
+            probed.isEmpty,
+            "None of the candidate Spanish headwords \(expectedTranslations.keys.sorted()) were found in '\(Self.spanishWordNetSource)'. The dictionary is too small or mis-tagged."
+        )
+
+        for (spanish, definition) in probed {
+            XCTAssertFalse(
+                definition.isEmpty,
+                "Spanish WordNet entry '\(spanish)' must have a non-empty definition"
+            )
+            // The synset must have mapped to the correct English word —
+            // the alignment-correctness check, not just "some text exists".
+            let expectedEnglish = expectedTranslations[spanish]!
+            XCTAssertTrue(
+                definition.range(of: expectedEnglish, options: .caseInsensitive) != nil,
+                "Definition for Spanish '\(spanish)' must contain the English translation '\(expectedEnglish)' (synset alignment); got: \(definition.prefix(160))"
+            )
+        }
+    }
+
+    /// `SettingsService.isEnabled(source: "wordnet-spa-eng")` must follow
+    /// the first-launch-all-enabled then toggle-persists contract,
+    /// paralleling the other per-source toggle tests.
+    func testSpanishWordNetSourceTogglePersists() throws {
+        let service = SettingsService.shared
+
+        // Snapshot + restore so we don't bleed state into adjacent tests.
+        let originalEnabled = service.enabledSources
+        addTeardownBlock {
+            service.enabledSources = originalEnabled
+        }
+
+        // First-launch state: every source enabled, including unknown ones.
+        service.enabledSources = nil
+        XCTAssertTrue(
+            service.isEnabled(source: Self.spanishWordNetSource),
+            "First-launch state must treat \(Self.spanishWordNetSource) as enabled"
+        )
+
+        let known: Set<String> = ["wordnet", "openrussian", "freedict-eng-spa", Self.spanishWordNetSource]
+
+        // Toggle off — siblings must remain enabled.
+        service.setEnabled(false, for: Self.spanishWordNetSource, knownSources: known)
+        XCTAssertFalse(
+            service.isEnabled(source: Self.spanishWordNetSource),
+            "After setEnabled(false), wordnet-spa-eng must report disabled"
+        )
+        XCTAssertTrue(service.isEnabled(source: "freedict-eng-spa"),
+                      "Disabling wordnet-spa-eng must not affect the eng-spa source")
+        XCTAssertTrue(service.isEnabled(source: "wordnet"))
+
+        // Persisted set must exclude ours and keep the others.
+        let stored = service.enabledSources
+        XCTAssertNotNil(stored, "Persisted enabledSources must exist after any setEnabled call")
+        XCTAssertFalse(stored?.contains(Self.spanishWordNetSource) ?? true,
+                       "Persisted set must not contain wordnet-spa-eng after toggling it off")
+        XCTAssertTrue(stored?.contains("freedict-eng-spa") ?? false)
+
+        // Toggle back on.
+        service.setEnabled(true, for: Self.spanishWordNetSource, knownSources: known)
+        XCTAssertTrue(
+            service.isEnabled(source: Self.spanishWordNetSource),
+            "Re-enabling wordnet-spa-eng must be visible immediately"
+        )
+        XCTAssertTrue(service.enabledSources?.contains(Self.spanishWordNetSource) ?? false,
+                      "Re-enable must round-trip through UserDefaults")
+    }
+
     // MARK: - Performance Tests
 
     /// Measures FTS5 search time on a 100,000-entry database. Target: < 16ms.

--- a/Scripts/build_seed.py
+++ b/Scripts/build_seed.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 """
 build_seed.py
-Downloads WordNet (En-En), OpenRussian (Ru-En) and FreeDict eng-spa
-(En-Es) dictionaries, then builds a single seed.sqlite containing all
-three sources, an FTS5 index, and a metadata table.
+Downloads WordNet (En-En), OpenRussian (Ru-En), FreeDict eng-spa
+(En-Es) and Spanish WordNet (Es-En) dictionaries, then builds a single
+seed.sqlite containing all four sources, an FTS5 index, and a metadata
+table.
 
 Sources:
-  - WordNet 3.1 via NLTK   (BSD license, Princeton University)
+  - WordNet 3.0 via NLTK   (BSD license, Princeton University)
   - OpenRussian.org         (CC-BY-SA 4.0, community-maintained)
   - FreeDict eng-spa        (GPL-3.0, freedict.org — TEI/XML)
+  - Spanish WordNet         (CC BY 3.0, MCR / OMW via NLTK)
 
 Source-identifier convention used by this builder:
   - single-monolingual / unambiguous → bare provider name
         e.g. "wordnet", "openrussian".
   - bilingual / multi-direction → "provider-srclang-tgtlang" with
-    ISO-639-3 codes, e.g. "freedict-eng-spa".
+    ISO-639-3 codes, e.g. "freedict-eng-spa", "wordnet-spa-eng".
 
 Requirements:
     pip install nltk requests defusedxml
@@ -23,9 +25,10 @@ Usage (from project root):
     source .venv/bin/activate
     python Scripts/build_seed.py
     python Scripts/build_seed.py --output DictApp/DictApp/Resources/seed.sqlite
-    python Scripts/build_seed.py --skip-russian   # WordNet only (plus eng-spa)
-    python Scripts/build_seed.py --skip-spanish   # skip FreeDict eng-spa
-    python Scripts/build_seed.py --limit 5000     # subset WordNet (testing)
+    python Scripts/build_seed.py --skip-russian          # skip OpenRussian
+    python Scripts/build_seed.py --skip-spanish          # skip FreeDict eng-spa
+    python Scripts/build_seed.py --skip-spanish-wordnet  # skip Spanish WordNet
+    python Scripts/build_seed.py --limit 5000            # subset WordNet (testing)
 """
 
 import argparse
@@ -164,7 +167,7 @@ def extract_pos_tags(synsets) -> str:
 
 def insert_wordnet(cur: sqlite3.Cursor, conn: sqlite3.Connection,
                    limit: int | None = None) -> int:
-    print("\n[1/3] WordNet (En-En)")
+    print("\n[1/4] WordNet (En-En)")
     nltk = ensure_nltk()
     from nltk.corpus import wordnet as wn
 
@@ -202,7 +205,7 @@ def insert_wordnet(cur: sqlite3.Cursor, conn: sqlite3.Connection,
     count = cur.execute(
         "SELECT COUNT(*) FROM entries WHERE source='wordnet'").fetchone()[0]
     wordnet_license = (
-        "WordNet 3.1 License (BSD-style)\n\n"
+        "WordNet 3.0 License (BSD-style)\n\n"
         "Copyright 2006 by Princeton University. All rights reserved.\n\n"
         "THIS SOFTWARE AND DATABASE IS PROVIDED \"AS IS\" AND PRINCETON "
         "UNIVERSITY MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR "
@@ -235,7 +238,7 @@ def insert_wordnet(cur: sqlite3.Cursor, conn: sqlite3.Connection,
     cur.execute(
         "INSERT OR REPLACE INTO dict_metadata(source, display_name, version, license, url, word_count, built_at, description) "
         "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-        ("wordnet", "WordNet", "3.1",
+        ("wordnet", "WordNet", "3.0",
          wordnet_license,
          "https://wordnet.princeton.edu/",
          count, datetime.now(tz=None).isoformat(),
@@ -294,7 +297,7 @@ def parse_openrussian(csv_files: dict[str, str]) -> list[tuple]:
 
 
 def insert_openrussian(cur: sqlite3.Cursor, conn: sqlite3.Connection) -> int:
-    print("\n[2/3] OpenRussian (Ru-En)")
+    print("\n[2/4] OpenRussian (Ru-En)")
     requests_mod = ensure_requests()
 
     try:
@@ -370,7 +373,7 @@ def insert_openrussian(cur: sqlite3.Cursor, conn: sqlite3.Connection) -> int:
 # ---------------------------------------------------------------------------
 
 def insert_freedict_eng_spa(cur: sqlite3.Cursor, conn: sqlite3.Connection) -> int:
-    print("\n[3/3] FreeDict (En-Es)")
+    print("\n[3/4] FreeDict (En-Es)")
     # Imported lazily so a `--skip-spanish` run doesn't need the module
     # (and so a tools-checkout with an old build_seed.py won't crash on
     # a missing sibling file).
@@ -429,6 +432,67 @@ def insert_freedict_eng_spa(cur: sqlite3.Cursor, conn: sqlite3.Connection) -> in
 
 
 # ---------------------------------------------------------------------------
+# Spanish WordNet (Es-En)
+# ---------------------------------------------------------------------------
+
+def insert_spanish_wordnet(cur: sqlite3.Cursor, conn: sqlite3.Connection) -> int:
+    print("\n[4/4] Spanish WordNet (Es-En)")
+    # Imported lazily so a `--skip-spanish-wordnet` run doesn't need the
+    # module (and so an old tools-checkout won't crash on a missing
+    # sibling file).
+    from build_spanish_wordnet import (
+        build_and_collect,
+        DESCRIPTION_TEXT,
+        DISPLAY_NAME,
+        LICENSE_TEXT,
+        SOURCE,
+        URL as METADATA_URL,
+    )
+
+    # No try/except: this runs only when --skip-spanish-wordnet was not
+    # passed, so a failure must surface rather than silently shipping a
+    # seed without the requested dictionary.
+    entries, version = build_and_collect()
+
+    print(f"  Built {len(entries)} Es-En entries.")
+
+    batch, inserted = [], 0
+    total = len(entries)
+    for i, row in enumerate(entries):
+        batch.append(row)
+        if len(batch) >= 500:
+            cur.executemany(
+                "INSERT OR IGNORE INTO entries(word, definition, phonetic, pos, source) "
+                "VALUES (?, ?, ?, ?, ?)", batch)
+            conn.commit()
+            inserted += len(batch)
+            batch.clear()
+            if total > 0:
+                pct = int((i + 1) / total * 100)
+                print(f"\r  [{pct:3d}%] {inserted} entries...", end="", flush=True)
+    if batch:
+        cur.executemany(
+            "INSERT OR IGNORE INTO entries(word, definition, phonetic, pos, source) "
+            "VALUES (?, ?, ?, ?, ?)", batch)
+        conn.commit()
+        inserted += len(batch)
+
+    count = cur.execute(
+        "SELECT COUNT(*) FROM entries WHERE source=?", (SOURCE,)).fetchone()[0]
+    cur.execute(
+        "INSERT OR REPLACE INTO dict_metadata(source, display_name, version, license, url, word_count, built_at, description) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (SOURCE, DISPLAY_NAME, version,
+         LICENSE_TEXT,
+         METADATA_URL,
+         count, datetime.now(tz=None).isoformat(),
+         DESCRIPTION_TEXT))
+    conn.commit()
+    print(f"\n  Spanish WordNet: {count} entries")
+    return count
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -443,6 +507,8 @@ def main():
                         help="Skip the OpenRussian dictionary.")
     parser.add_argument("--skip-spanish", action="store_true",
                         help="Skip the FreeDict English-Spanish dictionary.")
+    parser.add_argument("--skip-spanish-wordnet", action="store_true",
+                        help="Skip the Spanish WordNet (Spanish-English) dictionary.")
     args = parser.parse_args()
 
     os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
@@ -464,6 +530,9 @@ def main():
     es_count = 0
     if not args.skip_spanish:
         es_count = insert_freedict_eng_spa(cur, conn)
+    spa_wn_count = 0
+    if not args.skip_spanish_wordnet:
+        spa_wn_count = insert_spanish_wordnet(cur, conn)
 
     # Rebuild FTS index in bulk. Per-row triggers already kept it in sync
     # during the inserts, but a final rebuild produces a smaller,
@@ -483,6 +552,7 @@ def main():
     print(f"  WordNet  : {wn_count:,} entries")
     print(f"  OpenRus  : {ru_count:,} entries")
     print(f"  FreeDict : {es_count:,} entries")
+    print(f"  Spa-WN   : {spa_wn_count:,} entries")
     print(f"  Total    : {total:,} entries")
     print(f"{'='*50}")
 

--- a/Scripts/build_spanish_wordnet.py
+++ b/Scripts/build_spanish_wordnet.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+build_spanish_wordnet.py
+Build a Spanish→English dictionary from the Open Multilingual WordNet
+(OMW) Spanish data — the spa→eng counterpart to the FreeDict eng-spa
+dictionary delivered in Issue #24.
+
+Strategy (see DESIGN_DOC.md, Issue #42): the synset join happens in
+Python against a single, synset-aware NLTK WordNet instance. Spanish
+lemmas (`Synset.lemma_names('spa')`) and the English glosses/synonyms
+(`Synset.definition()` / `Synset.lemma_names()`) are read from the *same*
+WordNet object, so the synset IDs are shared by construction — there is
+no cross-version offset table to misalign. The app never sees synset
+IDs; it receives flat `entries` rows exactly like every other source.
+
+Source identifier: "wordnet-spa-eng" (provider-srclang-tgtlang, matching
+the #24 convention used by "freedict-eng-spa").
+
+Usage:
+    python Scripts/build_spanish_wordnet.py            # print summary
+    python Scripts/build_spanish_wordnet.py --dump 5   # print 5 entries
+
+Requirements (NLTK + the WordNet and OMW corpora):
+    pip install nltk
+    # corpora are fetched on first run via nltk.download()
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+# ---------------------------------------------------------------------------
+# Public constants — consumed by build_seed.py for dict_metadata.
+# ---------------------------------------------------------------------------
+
+SOURCE = "wordnet-spa-eng"
+DISPLAY_NAME = "Spanish – English (WordNet)"
+URL = "https://adimen.si.ehu.es/web/MCR"
+
+LICENSE_TEXT = (
+    "Spanish WordNet — Multilingual Central Repository (MCR), "
+    "distributed via the Open Multilingual WordNet (OMW).\n\n"
+    "The Spanish WordNet data is licensed under the Creative Commons "
+    "Attribution 3.0 Unported License (CC BY 3.0).\n\n"
+    "You are free to share and adapt the material for any purpose, even "
+    "commercially, provided you give appropriate credit to the "
+    "Multilingual Central Repository (University of the Basque Country) "
+    "and the Open Multilingual WordNet project.\n\n"
+    "The English glosses and synset structure derive from Princeton "
+    "WordNet 3.0, used under the WordNet 3.0 License (BSD-style), "
+    "Copyright 2006 Princeton University.\n\n"
+    "Full license texts:\n"
+    "  • https://creativecommons.org/licenses/by/3.0/\n"
+    "  • https://wordnet.princeton.edu/license-and-commercial-use"
+)
+
+DESCRIPTION_TEXT = (
+    "Spanish WordNet provides Spanish lemmas aligned to Princeton "
+    "WordNet synsets. Each Spanish headword is mapped to its English "
+    "translation lemmas and the English gloss for every sense, grouped "
+    "by part of speech.\n\n"
+    "The data comes from the Multilingual Central Repository (MCR), "
+    "maintained at the University of the Basque Country (UPV/EHU), and "
+    "is accessed here through the Open Multilingual WordNet (OMW) "
+    "packaged with NLTK. Because the Spanish lemmas and English glosses "
+    "are read from the same WordNet 3.0 instance, the synset mapping is "
+    "exact — no cross-version alignment is involved."
+)
+
+# Spanish lemma lookup language code used by NLTK/OMW.
+_OMW_LANG = "spa"
+
+
+# ---------------------------------------------------------------------------
+# NLTK bootstrap (data download only — never a runtime `pip install`)
+# ---------------------------------------------------------------------------
+
+def _ensure_nltk():
+    """Return the `nltk` module, failing fast if it isn't installed, and
+    ensure the WordNet + OMW corpora are present.
+
+    Like the #24 build scripts, we never `pip install` at runtime (that
+    makes builds non-deterministic and breaks in offline CI). Corpus
+    *data* downloads via `nltk.download()` are the standard NLTK
+    bootstrap and mirror `build_seed.ensure_nltk()`."""
+    try:
+        import nltk
+    except ImportError as err:
+        raise RuntimeError(
+            "Missing build dependency 'nltk'. Install it first: pip install nltk"
+        ) from err
+    for corpus in ("wordnet", "omw-1.4"):
+        try:
+            nltk.data.find(f"corpora/{corpus}")
+        except LookupError:
+            print(f"  Downloading NLTK corpus: {corpus}...")
+            if not nltk.download(corpus, quiet=True):
+                raise RuntimeError(
+                    f"Failed to download required NLTK corpus '{corpus}'. "
+                    "Ensure network access or pre-install the NLTK data."
+                )
+    return nltk
+
+
+# ---------------------------------------------------------------------------
+# Synset → row construction
+# ---------------------------------------------------------------------------
+
+# Mirror build_seed.pos_tag_to_label so the POS line is consistent across
+# sources. Kept local so this module stays stand-alone runnable.
+_POS_LABEL = {
+    "n": "noun",
+    "v": "verb",
+    "a": "adjective",
+    "r": "adverb",
+    "s": "adjective satellite",
+}
+
+
+def _pos_label(pos: str) -> str:
+    return _POS_LABEL.get(pos, pos)
+
+
+def _build_definition(synsets) -> str:
+    """Format senses as markdown, grouped by POS. Each sense leads with
+    the English translation lemmas (the payload a Spanish speaker wants)
+    followed by the English gloss:
+
+        **noun**
+        1. house, home — a dwelling that serves as living quarters ...
+        2. firm, house, business — the members of a business organization ...
+    """
+    by_pos: dict[str, list] = {}
+    for ss in synsets:
+        by_pos.setdefault(_pos_label(ss.pos()), []).append(ss)
+
+    # Iterate POS blocks and senses in a stable order so rebuilds produce
+    # byte-identical definitions (avoids noisy seed.sqlite diffs). Synsets
+    # sort by their unique name (e.g. "house.n.01"), which is deterministic.
+    parts: list[str] = []
+    for pos_label in sorted(by_pos):
+        senses = sorted(by_pos[pos_label], key=lambda ss: ss.name())
+        parts.append(f"**{pos_label}**")
+        for i, ss in enumerate(senses, 1):
+            english_lemmas = ", ".join(
+                name.replace("_", " ") for name in ss.lemma_names()
+            )
+            gloss = ss.definition() or ""
+            if english_lemmas and gloss:
+                parts.append(f"{i}. {english_lemmas} — {gloss}")
+            elif english_lemmas:
+                parts.append(f"{i}. {english_lemmas}")
+            else:
+                parts.append(f"{i}. {gloss}")
+        parts.append("")
+    return "\n".join(parts).strip()
+
+
+def _extract_pos_tags(synsets) -> str:
+    # Sort the de-duplicated POS labels so the `pos` column is stable
+    # across rebuilds (no traversal-order churn in the seed).
+    tags = {_pos_label(ss.pos()) for ss in synsets}
+    return ", ".join(sorted(tags))
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def build_and_collect() -> tuple[list[tuple], str]:
+    """Iterate every WordNet synset, index it by its Spanish lemmas, and
+    emit one spa→eng row per Spanish headword.
+
+    Returns:
+        (rows, version) where `rows` is the list of
+        `(word, definition, phonetic, pos, "wordnet-spa-eng")` tuples and
+        `version` describes the WordNet/OMW data actually used.
+    """
+    nltk = _ensure_nltk()  # noqa: F841 — ensures corpora are present
+    from nltk.corpus import wordnet as wn
+
+    wn_version = wn.get_version() or "unknown"
+    version = f"OMW 1.4 / WordNet {wn_version}"
+
+    # Index synsets by Spanish lemma. One Spanish word can belong to many
+    # synsets across multiple parts of speech.
+    spanish_index: dict[str, list] = {}
+    for ss in wn.all_synsets():
+        for lemma in ss.lemma_names(_OMW_LANG):
+            display = lemma.replace("_", " ")
+            spanish_index.setdefault(display, []).append(ss)
+
+    # Emit headwords in sorted order so the row sequence (and therefore
+    # the rebuilt seed.sqlite) is stable across runs.
+    rows: list[tuple] = []
+    for spanish_word in sorted(spanish_index):
+        synsets = spanish_index[spanish_word]
+        definition = _build_definition(synsets)
+        if not definition:
+            continue
+        pos = _extract_pos_tags(synsets)
+        rows.append((spanish_word, definition, "", pos, SOURCE))
+
+    return rows, version
+
+
+# ---------------------------------------------------------------------------
+# Stand-alone debug runner
+# ---------------------------------------------------------------------------
+
+def _main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dump", type=int, default=0,
+                    help="Print the first N built entries and exit.")
+    args = ap.parse_args()
+
+    rows, version = build_and_collect()
+    print(f"\nSpanish WordNet ({version}): {len(rows):,} entries built.")
+    for row in rows[: args.dump]:
+        word, definition, _phonetic, pos, _source = row
+        print(f"\n--- {word}  [{pos}] ---")
+        print(definition)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())


### PR DESCRIPTION
## Summary

Implements **Issue #42** — bundles a Spanish→English dictionary built from Spanish WordNet, the spa→eng counterpart to #24's eng-spa FreeDict.

## The blocker, and how it was resolved

The issue's plan was to map Spanish lemmas to our SQLite WordNet via shared synset IDs — but our `entries` table stores **no synset IDs** (they're flattened away during ingest). Per DESIGN_DOC.md, this PR takes **Strategy B**: resolve the synset join at *build time* against NLTK's WordNet + OMW (already a dependency). Spanish lemmas (`lemma_names('spa')`) and English glosses/synonyms are read from one WordNet 3.0 instance, so synset IDs align **by construction** — no LKB parser, no cross-version corruption risk. The app keeps seeing opaque `entries` rows.

## Build numbers (regenerated seed.sqlite)

| Source | Entries |
|---|---:|
| WordNet | 147,306 |
| OpenRussian | 45,647 |
| FreeDict eng-spa | 58,946 |
| **Spanish WordNet (spa-eng)** | **36,371** |
| **Total** | **288,270** |

Seed size **87.8 MB** (≥30k spa-eng criterion ✅; under the 100 MB ceiling — though #11 on-demand download is the right answer for anything beyond this).

## Changes

- **`Scripts/build_spanish_wordnet.py`** (new) — indexes synsets by Spanish lemma, emits `wordnet-spa-eng` rows whose definition leads with English translations + gloss, grouped by POS. Stand-alone runnable; fails fast on missing `nltk` (no runtime `pip install`).
- **`Scripts/build_seed.py`** — `insert_spanish_wordnet()`, `--skip-spanish-wordnet`, summary line; **drive-by fix**: English `wordnet` metadata version `3.1`→`3.0` (the data was always 3.0).
- **`Models.swift`** — `case "wordnet-spa-eng": return "Es–En"`.
- **`CreditsView.swift`** + **`Localizable.xcstrings`** — `credits.dataSources.spanishWordnet` (en + ru).
- **`DictAppTests.swift`** — 4 unit tests (filled in by QA): source label, metadata row, headword searchability, per-source toggle.
- **`seed.sqlite`** — regenerated, committed via Git LFS.

## No-change list (deliberate)

`Schema.sql`, `DatabaseService.swift`, view-models, search/Settings/Detail views — the data layer was already source-agnostic.

## Synset alignment correctness

The headword test asserts `casa`'s definition contains `house` (and friends), so a silent synset-version misalignment would **fail** rather than pass. Verified: `casa`→house/home/dwelling, `perro`→dog, `agua`→water.

## Test plan

- [x] Build clean on iOS Simulator.
- [x] Seed has 4 populated sources; `dict_metadata` rows complete; `wordnet` version now `3.0`, `wordnet-spa-eng` version `OMW 1.4 / WordNet 3.0`.
- [x] `DictAppTests` — **49 passed, 0 failed**, including all 4 `testSpanishWordNet*`.
- [ ] Spanish-word UI test (mirroring #24's) — QA to add now that the seed is in.

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundled Spanish–English dictionary (WordNet) with an “Es–En” badge; enabled by default on first launch.

* **Documentation**
  * CHANGELOG updated; credits entry added and localized (English, Russian); WordNet metadata version corrected.

* **Views**
  * Credits screen now lists the Spanish WordNet data source.

* **Tests**
  * Added tests for Spanish WordNet integration, data integrity, metadata, and preference persistence.

* **Chores**
  * Updated bundled seed data artifact to include Spanish–English entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyukhin/dict-app/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->