### PR TITLE
test: Bump Spanish cold-seed timeout to match Arabic suite

### DIFF
--- a/DictApp/DictAppUITests/TestCases/SpanishLocalizationTests.swift
+++ b/DictApp/DictAppUITests/TestCases/SpanishLocalizationTests.swift
@@ -139,7 +139,10 @@ final class SpanishLocalizationTests: XCTestCase {
     /// The tab bar, waited into existence.
     private var tabBar: XCUIElement {
         let bar = app.tabBars.firstMatch
-        _ = bar.waitForExistence(timeout: 10)
+        // 60s — absorbs the one-time ~306k-row seed import on a fresh-install /
+        // cold launch (~104 MB seed.sqlite). Matches ArabicLocalizationTests; bumped
+        // per #54 after the post-#10 seed growth exposed the 10s ceiling.
+        _ = bar.waitForExistence(timeout: 60)
         return bar
     }
 


### PR DESCRIPTION
## Summary
- Bump tabBar `waitForExistence` from 10s to 60s in `SpanishLocalizationTests` to absorb the ~104 MB / 306k-row cold-seed import that #10 introduced.
- Matches `ArabicLocalizationTests` (which was already bumped to 60s during #9 QA for the same reason; Spanish was missed at the time because it ran warm).
- One file, one wait — other timeouts untouched.

## Test plan
- [x] arm64 `SpanishLocalizationTests` 5× sequential, uninstall-between (true cold seed): 5/5 pass, ~92s/run.
- [x] arm64 `ArabicLocalizationTests` 1× after uninstall: 5/5 pass (no regression).
- [x] Intel x86_64 `SpanishLocalizationTests` 1× pre-warm recipe: 3/3 pass.

Closes #54


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by adjusting timing for UI element detection on fresh installations and cold launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->