### PR TITLE
test: Force portrait orientation in UI test setUp

### DIFF
--- a/DictApp/DictAppUITests/DictAppUITests.swift
+++ b/DictApp/DictAppUITests/DictAppUITests.swift
@@ -7,6 +7,10 @@ final class DictAppUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
+        // Force portrait — sim orientation persists across sessions on Intel x86_64,
+        // and landscape no-ops swipeUp against SwiftUI Form/List scroll views.
+        // See project memory project_xcuitest_orientation_landscape_swipe.
+        XCUIDevice.shared.orientation = .portrait
         app.launch()
     }
 

--- a/DictApp/DictAppUITests/TestCases/ArabicLocalizationTests.swift
+++ b/DictApp/DictAppUITests/TestCases/ArabicLocalizationTests.swift
@@ -50,6 +50,10 @@ final class ArabicLocalizationTests: XCTestCase {
         app.launchArguments += ["-AppleLanguages", "(ar)"]
         app.launchArguments += ["-AppleLocale", "ar"]
         app.launchArguments.append("-resetData")
+        // Force portrait — sim orientation persists across sessions on Intel x86_64,
+        // and landscape no-ops swipeUp against SwiftUI Form/List scroll views.
+        // See project memory project_xcuitest_orientation_landscape_swipe.
+        XCUIDevice.shared.orientation = .portrait
         app.launch()
     }
 

--- a/DictApp/DictAppUITests/TestCases/BookmarkFlowTests.swift
+++ b/DictApp/DictAppUITests/TestCases/BookmarkFlowTests.swift
@@ -13,6 +13,10 @@ final class BookmarkFlowTests: XCTestCase {
         if name != "testBookmarkPersistence" {
             app.launchArguments.append("-resetData")
         }
+        // Force portrait — sim orientation persists across sessions on Intel x86_64,
+        // and landscape no-ops swipeUp against SwiftUI Form/List scroll views.
+        // See project memory project_xcuitest_orientation_landscape_swipe.
+        XCUIDevice.shared.orientation = .portrait
         app.launch()
 
         tabBarPage = TabBarPage(app: app)

--- a/DictApp/DictAppUITests/TestCases/DictionaryFilterTests.swift
+++ b/DictApp/DictAppUITests/TestCases/DictionaryFilterTests.swift
@@ -93,6 +93,10 @@ final class DictionaryFilterTests: XCTestCase {
             return false
         }
 
+        // Force portrait — sim orientation persists across sessions on Intel x86_64,
+        // and landscape no-ops swipeUp against SwiftUI Form/List scroll views.
+        // See project memory project_xcuitest_orientation_landscape_swipe.
+        XCUIDevice.shared.orientation = .portrait
         app.launch()
         tabBarPage = TabBarPage(app: app)
     }

--- a/DictApp/DictAppUITests/TestCases/HistoryFlowTests.swift
+++ b/DictApp/DictAppUITests/TestCases/HistoryFlowTests.swift
@@ -26,6 +26,10 @@ final class HistoryFlowTests: XCTestCase {
             return false
         }
 
+        // Force portrait — sim orientation persists across sessions on Intel x86_64,
+        // and landscape no-ops swipeUp against SwiftUI Form/List scroll views.
+        // See project memory project_xcuitest_orientation_landscape_swipe.
+        XCUIDevice.shared.orientation = .portrait
         app.launch()
         tabBarPage = TabBarPage(app: app)
     }

--- a/DictApp/DictAppUITests/TestCases/ImportDictionaryTests.swift
+++ b/DictApp/DictAppUITests/TestCases/ImportDictionaryTests.swift
@@ -37,6 +37,10 @@ final class ImportDictionaryTests: XCTestCase {
             return false
         }
 
+        // Force portrait — sim orientation persists across sessions on Intel x86_64,
+        // and landscape no-ops swipeUp against SwiftUI Form/List scroll views.
+        // See project memory project_xcuitest_orientation_landscape_swipe.
+        XCUIDevice.shared.orientation = .portrait
         app.launch()
         tabBarPage = TabBarPage(app: app)
     }

--- a/DictApp/DictAppUITests/TestCases/NavigationTests.swift
+++ b/DictApp/DictAppUITests/TestCases/NavigationTests.swift
@@ -8,6 +8,10 @@ final class NavigationTests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
+        // Force portrait — sim orientation persists across sessions on Intel x86_64,
+        // and landscape no-ops swipeUp against SwiftUI Form/List scroll views.
+        // See project memory project_xcuitest_orientation_landscape_swipe.
+        XCUIDevice.shared.orientation = .portrait
         app.launch()
 
         tabBarPage = TabBarPage(app: app)

--- a/DictApp/DictAppUITests/TestCases/ReportBugFlowTests.swift
+++ b/DictApp/DictAppUITests/TestCases/ReportBugFlowTests.swift
@@ -21,6 +21,10 @@ final class ReportBugFlowTests: XCTestCase {
         continueAfterFailure = false
         app = XCUIApplication()
         app.launchArguments = ["-resetData"]
+        // Force portrait — sim orientation persists across sessions on Intel x86_64,
+        // and landscape no-ops swipeUp against SwiftUI Form/List scroll views.
+        // See project memory project_xcuitest_orientation_landscape_swipe.
+        XCUIDevice.shared.orientation = .portrait
         app.launch()
     }
 

--- a/DictApp/DictAppUITests/TestCases/SearchFlowTests.swift
+++ b/DictApp/DictAppUITests/TestCases/SearchFlowTests.swift
@@ -27,6 +27,10 @@ final class SearchFlowTests: XCTestCase {
             return false
         }
 
+        // Force portrait — sim orientation persists across sessions on Intel x86_64,
+        // and landscape no-ops swipeUp against SwiftUI Form/List scroll views.
+        // See project memory project_xcuitest_orientation_landscape_swipe.
+        XCUIDevice.shared.orientation = .portrait
         app.launch()
         tabBarPage = TabBarPage(app: app)
         searchPage = tabBarPage.tapSearchTab()

--- a/DictApp/DictAppUITests/TestCases/SpanishLocalizationTests.swift
+++ b/DictApp/DictAppUITests/TestCases/SpanishLocalizationTests.swift
@@ -34,6 +34,10 @@ final class SpanishLocalizationTests: XCTestCase {
         continueAfterFailure = false
         app = XCUIApplication()
         app.launchArguments.append("-resetData")
+        // Force portrait — sim orientation persists across sessions on Intel x86_64,
+        // and landscape no-ops swipeUp against SwiftUI Form/List scroll views.
+        // See project memory project_xcuitest_orientation_landscape_swipe.
+        XCUIDevice.shared.orientation = .portrait
         app.launch()
     }
 

--- a/DictApp/DictAppUITests/TestCases/VersionDisplayTests.swift
+++ b/DictApp/DictAppUITests/TestCases/VersionDisplayTests.swift
@@ -17,6 +17,10 @@ final class VersionDisplayTests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
+        // Force portrait — sim orientation persists across sessions on Intel x86_64,
+        // and landscape no-ops swipeUp against SwiftUI Form/List scroll views.
+        // See project memory project_xcuitest_orientation_landscape_swipe.
+        XCUIDevice.shared.orientation = .portrait
         app.launch()
         tabBarPage = TabBarPage(app: app)
     }


### PR DESCRIPTION
## Summary
- Add `XCUIDevice.shared.orientation = .portrait` to each UI-test suite's `setUp()` before `app.launch()` (11 suites).
- Defensive against sim orientation state persisting across sessions on Intel x86_64 (landscape no-ops `swipeUp` on SwiftUI Form/List).
- Zero cost on arm64 (already portrait); fixes Intel for any scrollable-view test.
- Test-only — no production source changes.

## Test plan
- [x] arm64 `VersionDisplayTests` 1× — pass (force is no-op).
- [x] arm64 spot-check suite — no regression.
- [x] Intel in-test injection: `.landscapeLeft` injected before setUp's force → app launches landscape → setUp portrait force overrides → swipeUp progresses → `version_value` reachable → test passes.

Closes #65
Closes #64 item 3 (`VersionDisplayTests` on Intel).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized device orientation configuration across all UI test suites by explicitly setting the device to portrait mode during test setup. This ensures consistent behavior across test sessions, prevents orientation-related test failures, and improves overall reliability of the automated UI testing framework across different testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->