### PR TITLE
test: Bump Arabic cold-seed timeouts to match Spanish

### DIFF
--- a/DictApp/DictAppUITests/TestCases/ArabicLocalizationTests.swift
+++ b/DictApp/DictAppUITests/TestCases/ArabicLocalizationTests.swift
@@ -282,7 +282,9 @@ final class ArabicLocalizationTests: XCTestCase {
     private func search(for term: String) {
         dismissSiriPrivacyNoticeIfPresent()
         let field = app.searchFields.firstMatch
-        XCTAssertTrue(field.waitForExistence(timeout: 10), "Search field must exist")
+        // 60s — absorbs the one-time ~306k-row cold seed; matches
+        // testMixedScriptCellRenders and SpanishLocalizationTests, post-#54.
+        XCTAssertTrue(field.waitForExistence(timeout: 60), "Search field must exist")
         field.tap()
         dismissSiriPrivacyNoticeIfPresent()
         // Re-resolve in case the privacy sheet dismissal re-laid out the field.
@@ -319,7 +321,9 @@ final class ArabicLocalizationTests: XCTestCase {
     /// The tab bar, waited into existence.
     private var tabBar: XCUIElement {
         let bar = app.tabBars.firstMatch
-        _ = bar.waitForExistence(timeout: 10)
+        // 60s — absorbs the one-time ~306k-row cold seed; matches
+        // testMixedScriptCellRenders and SpanishLocalizationTests, post-#54.
+        _ = bar.waitForExistence(timeout: 60)
         return bar
     }
 


### PR DESCRIPTION
## Summary
- Bump two `waitForExistence(timeout: 10)` calls in `ArabicLocalizationTests` to `60s` — the cold-seed-bearing critical path.
- Compound cold-seed budget for `testAppLaunchesInArabic` goes from 10+60=70s (insufficient on Intel) to 60+60=120s (absorbs the ~84–100s Intel seed).
- No single wait exceeds 60s — structural cleanup of a hidden short-wait bug, not ceiling-pushing.
- Test-only — no production source changes.

## Test plan
- [x] arm64 `ArabicLocalizationTests` 5/5 × 5 sequential, uninstall-between.
- [x] Intel x86_64 `ArabicLocalizationTests` 5/5 × 5 sequential, uninstall-between (AC-binding).
- [x] Regression: `SpanishLocalizationTests` and other UI suites unchanged.

Closes #62
Closes #64 item — `ArabicLocalizationTests` on Intel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced Arabic localization test stability by extending UI element wait times to accommodate one-time initialization processes during cold app launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->