### PR TITLE
test: Bump Spanish selectLanguage cold-seed wait to 60s

### DIFF
--- a/DictApp/DictAppUITests/TestCases/SpanishLocalizationTests.swift
+++ b/DictApp/DictAppUITests/TestCases/SpanishLocalizationTests.swift
@@ -181,7 +181,9 @@ final class SpanishLocalizationTests: XCTestCase {
     @discardableResult
     private func selectLanguage(code: String) -> Bool {
         let bar = app.tabBars.firstMatch
-        guard bar.waitForExistence(timeout: 10) else { return false }
+        // 60s — absorbs the one-time ~306k-row cold seed; matches the
+        // tabBar getter post-#54.
+        guard bar.waitForExistence(timeout: 60) else { return false }
         let settings = bar.buttons.element(boundBy: settingsTabIndex)
         guard settings.waitForExistence(timeout: 5) else { return false }
         settings.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()


### PR DESCRIPTION
## Summary
- Bump `SpanishLocalizationTests.selectLanguage`'s local `bar.waitForExistence(timeout: 10)` to `60s` — the cold-seed-bearing helper that #54 explicitly left at 10s, mistakenly judging it warm-path.
- Eliminates the deterministic 22.3s / 22.4s `selectLanguage` cold-seed failure on Intel and arm64.
- Same shape and rationale as #54 and #62.
- Test-only — no production source changes.

## Test plan
- [x] Intel x86_64 `SpanishLocalizationTests` 5/5 × 5 sequential, uninstall-between (AC-binding).
- [x] arm64 — 22.3s/22.4s `selectLanguage` fail eliminated. (Other arm64 sim flakes are pre-existing environmental — tracked in #67.)
- [x] Intel `ArabicLocalizationTests` regression clean (5/5 standalone).

Closes #66
Closes #64 — `SpanishLocalizationTests` on Intel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced Spanish language selection test stability by increasing timeout thresholds for tab bar verification, ensuring consistent execution under various system conditions.
  * Updated test documentation to align with recent improvements in timeout handling and framework behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->