### PR TITLE
fix: Stabilize iPad tab-switch in TabBarPage UITest helper

### DIFF
--- a/DictApp/DictAppUITests/PageObjects/TabBarPage.swift
+++ b/DictApp/DictAppUITests/PageObjects/TabBarPage.swift
@@ -60,17 +60,77 @@ class TabBarPage: BasePage {
 
     // MARK: - Navigation Methods
 
-    /// Taps a tab-bar element via a normalized center coordinate. XCUITest's
-    /// `.tap()` first invokes an AX `scrollToVisible` action; on iOS 26 with
-    /// certain SwiftUI layouts (notably after a NavigationLink push inside
-    /// the tab) that action fails with `kAXErrorCannotComplete`, breaking
-    /// tab navigation entirely. A coordinate tap skips `scrollToVisible`
-    /// and works as long as the element's frame is correct (which it is for
-    /// tab-bar buttons — they live in a fixed bottom strip).
+    /// Dismisses the software keyboard if it is showing. On iPad the keyboard
+    /// overlays the bottom tab strip after a `.searchable` search, leaving each
+    /// tab button present-but-unhittable — a tap then lands on a keyboard key
+    /// instead of the tab, so the switch silently no-ops (Issue #76). A no-op
+    /// when no keyboard is up, so it is harmless on the iPhone path.
+    private func dismissKeyboardIfPresent() {
+        guard app.keyboards.count > 0 else { return }
+        let hideKey = app.keyboards.buttons["Hide keyboard"]
+        if hideKey.exists {
+            hideKey.tap()
+        } else {
+            app.keyboards.firstMatch.swipeDown()
+        }
+        // Wait for the keyboard to retract so the tab strip becomes hittable.
+        let deadline = Date().addingTimeInterval(2.0)
+        while app.keyboards.count > 0 && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+    }
+
+    /// Taps a tab-bar element. XCUITest's `.tap()` first invokes an AX
+    /// `scrollToVisible` action; on iOS 26 with certain SwiftUI layouts
+    /// (notably after a NavigationLink push inside the tab) that action fails
+    /// with `kAXErrorCannotComplete`, breaking tab navigation entirely. A
+    /// coordinate tap skips `scrollToVisible` and works as long as the
+    /// element's frame is correct (which it is for tab-bar buttons — they live
+    /// in a fixed bottom strip). That is the iPhone path, unchanged.
+    ///
+    /// iPad needs two extra steps (Issue #76, verified by hierarchy dumps):
+    ///   1. The keyboard occludes the tab strip after a `.searchable` search,
+    ///      so dismiss it first (above) to make the button hittable.
+    ///   2. Even when hittable, a *raw coordinate* tap is swallowed while
+    ///      `.searchable` is still active (a "Cancel" button present) — only a
+    ///      direct element `.tap()` registers the switch (and clears the search).
+    /// So on iPad, once the button is hittable, prefer `.tap()`; otherwise fall
+    /// back to the coordinate tap.
     private func coordinateTap(_ element: XCUIElement) {
         // Make sure the element exists before computing a coordinate from it.
         _ = element.waitForExistence(timeout: TestData.Timeouts.medium)
-        element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+        dismissKeyboardIfPresent()
+        if UIDevice.current.userInterfaceIdiom == .pad && element.isHittable {
+            element.tap()
+        } else {
+            element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+        }
+        popDetailToRootIfNeeded()
+    }
+
+    /// Re-selecting an already-active tab pops its NavigationStack to root on
+    /// iPhone, but **not** on iPad (Issue #76): a pushed `DefinitionView` stays
+    /// on top, so a caller that taps e.g. the Search tab to start a fresh search
+    /// finds no search field (`SearchPage` "Search field should exist"). When a
+    /// detail view is still showing after the tab tap, pop it the same way
+    /// `DefinitionPage.navigateBack` does — tap the leading nav-bar button (the
+    /// back chevron). This is safe because the tab root views carry no leading
+    /// nav-bar button, so it only ever dismisses a pushed detail. iPhone is
+    /// unaffected (it has already popped, so the loop never runs).
+    private func popDetailToRootIfNeeded() {
+        guard UIDevice.current.userInterfaceIdiom == .pad else { return }
+        let detail = app.descendants(matching: .any)[AccessibilityIdentifiers.Definition.definitionView]
+        var guardCount = 0
+        while detail.exists && guardCount < 4 {
+            let backButton = app.navigationBars.firstMatch.buttons.element(boundBy: 0)
+            guard backButton.exists && backButton.isHittable else { break }
+            backButton.tap()
+            guardCount += 1
+            // Wait on the detail view's disappearance — not the nav bar's existence
+            // (which is typically already present pre-tap and doesn't synchronize
+            // with the pop animation, so the loop could fire mid-transition).
+            _ = detail.waitForNonExistence(timeout: TestData.Timeouts.short)
+        }
     }
 
     @discardableResult


### PR DESCRIPTION
## Summary
- iPad UITests failed because `.searchable` keyboard occludes the tab strip and coordinate taps are swallowed while search is active; fix is a test-only `TabBarPage` change with iPad-only branch (element `.tap()` + keyboard dismiss + detail-view pop). iPhone code path byte-identical.

## Test plan
- [x] iPad Pro 11" RED→GREEN: `HistoryFlowTests` 1/9 → 9/9; 4× per-suite stable on iPad (History 9/9, Search 7/7, Bookmark 8/8).
- [x] iPhone 17 Pro single-pass regression clean across all three suites.

Closes #76


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved iPad navigation testing with enhanced keyboard handling and detail-view cleanup during tab switching. Better test coverage for multi-view navigation state management on iPad devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->