### PR TITLE
test: Narrow #60 XCTSkip to iOS < 18.6 (Apple fixed in 18.6)

### DIFF
--- a/DictApp/DictAppUITests/TestCases/SearchFlowTests.swift
+++ b/DictApp/DictAppUITests/TestCases/SearchFlowTests.swift
@@ -101,10 +101,14 @@ final class SearchFlowTests: XCTestCase {
         // passed on arch/OS combos that materialize the long-def cells (arm64 /
         // iOS 26 stays green). Production-thread investigation tracked in #60;
         // `ALLOW_LONG_DEF_FLAKE` re-enables the test there without editing it.
+        // Apple fixed the drop in the iOS 18.6 SDK runtime (re-verified on the
+        // 18.6 sim, both current master and pre-#6), so the skip is now narrowed
+        // to iOS 18.0–18.5; 18.6+ renders the long cells and runs the test.
         #if arch(x86_64)
+        let os = ProcessInfo.processInfo.operatingSystemVersion
         if ProcessInfo.processInfo.environment["ALLOW_LONG_DEF_FLAKE"] == nil,
-           ProcessInfo.processInfo.operatingSystemVersion.majorVersion == 18 {
-            throw XCTSkip("Intel x86_64 + iOS 18.x sim drops long-definition cells; see #60.")
+           os.majorVersion == 18, os.minorVersion < 6 {
+            throw XCTSkip("Intel x86_64 + iOS 18.0–18.5 sim drops long-definition cells (fixed by Apple in iOS 18.6); see #60.")
         }
         #endif
 


### PR DESCRIPTION
## Summary
- Narrow the `testSearchToDefinitionNavigation` XCTSkip from `iOS 18.x` to `iOS 18.0–18.5` — Apple fixed the long-cell drop in iOS 18.6 (empirically verified both current master and pre-#6 master render the long-definition cells on the 18.6 sim; the issue is iOS 18.5 SDK runtime-bound, not #6's `SourceStripeRow` layout).

## Test plan
- [x] iOS 18.6 mini: `testSearchToDefinitionNavigation` reports **pass** (not skipped).
- [x] arm64 dev: `SearchFlowTests` 7/7 regression-pass.

Refs #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined test skip conditions for search flow tests on Intel x86_64 devices. The test now runs on iOS 18.6+ instead of being skipped across all iOS 18.x versions, improving test coverage on newer iOS releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->